### PR TITLE
No liquidation retrocompatible

### DIFF
--- a/contracts/MoC.sol
+++ b/contracts/MoC.sol
@@ -70,33 +70,33 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
 
   /****************************INTERFACE*******************************************/
 
-  function bproxBalanceOf(bytes32 bucket, address account) public view returns(uint256) {
-    return bproxManager.bproxBalanceOf(bucket, account);
-  }
+  // function bproxBalanceOf(bytes32 bucket, address account) public view returns(uint256) {
+  //   return bproxManager.bproxBalanceOf(bucket, account);
+  // }
 
   /**
     @dev Gets the RedeemRequest at the queue index position
     @param index queue position to get
     @return redeemer's address and amount he submitted
   */
-  function getRedeemRequestAt(uint256 index) public view returns(address, uint256) {
-    return settlement.getRedeemRequestAt(index);
-  }
+  // function getRedeemRequestAt(uint256 index) public view returns(address, uint256) {
+  //   return settlement.getRedeemRequestAt(index);
+  // }
 
   /**
     @dev returns current redeem queue size
    */
-  function redeemQueueSize() public view returns(uint256) {
-    return settlement.redeemQueueSize();
-  }
+  // function redeemQueueSize() public view returns(uint256) {
+  //   return settlement.redeemQueueSize();
+  // }
 
   /**
     @dev returns the total amount of Docs in the redeem queue for redeemer
     @param redeemer address for which ^ is computed
    */
-  function docAmountToRedeem(address redeemer) public view returns(uint256) {
-    return settlement.docAmountToRedeem(redeemer);
-  }
+  // function docAmountToRedeem(address redeemer) public view returns(uint256) {
+  //   return settlement.docAmountToRedeem(redeemer);
+  // }
 
 
   /**
@@ -119,9 +119,19 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
   /**
     @dev Mints BPRO and pays the comissions of the operation.
     @param btcToMint Amount in BTC to mint
+   */
+  function mintBPro(uint256 btcToMint)
+  public payable
+  whenNotPaused() transitionState() notInProtectionMode() {
+    mintBProVendors(btcToMint, address(0));
+  }
+
+  /**
+    @dev Mints BPRO and pays the comissions of the operation.
+    @param btcToMint Amount in BTC to mint
     @param vendorAccount Vendor address
    */
-  function mintBPro(uint256 btcToMint, address vendorAccount)
+  function mintBProVendors(uint256 btcToMint, address vendorAccount)
   public payable
   whenNotPaused() transitionState() notInProtectionMode() {
     /** UPDATE V0110: 24/09/2020 - Upgrade to support multiple commission rates **/
@@ -147,9 +157,19 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
   /**
    * @dev Redeems Bpro Tokens and pays the comissions of the operation
      @param bproAmount Amount in Bpro
+   */
+  function redeemBPro(uint256 bproAmount)
+  public
+  whenNotPaused() transitionState() atLeastState(MoCState.States.AboveCobj) {
+    redeemBProVendors(bproAmount, address(0));
+  }
+
+  /**
+   * @dev Redeems Bpro Tokens and pays the comissions of the operation
+     @param bproAmount Amount in Bpro
      @param vendorAccount Vendor address
    */
-  function redeemBPro(uint256 bproAmount, address vendorAccount)
+  function redeemBProVendors(uint256 bproAmount, address vendorAccount)
   public
   whenNotPaused() transitionState() atLeastState(MoCState.States.AboveCobj) {
     /** UPDATE V0110: 24/09/2020 - Upgrade to support multiple commission rates **/
@@ -168,9 +188,19 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
   /**
    * @dev Mint Doc tokens and pays the commisions of the operation
    * @param btcToMint Amount in RBTC to mint
+   */
+  function mintDoc(uint256 btcToMint)
+  public payable
+  whenNotPaused() transitionState() atLeastState(MoCState.States.AboveCobj) {
+    mintDocVendors(btcToMint, address(0));
+  }
+
+  /**
+   * @dev Mint Doc tokens and pays the commisions of the operation
+   * @param btcToMint Amount in RBTC to mint
    * @param vendorAccount Vendor address
    */
-  function mintDoc(uint256 btcToMint, address vendorAccount)
+  function mintDocVendors(uint256 btcToMint, address vendorAccount)
   public payable
   whenNotPaused() transitionState() atLeastState(MoCState.States.AboveCobj) {
     /** UPDATE V0110: 24/09/2020 - Upgrade to support multiple commission rates **/
@@ -197,9 +227,20 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
      @dev Redeems Bprox Tokens and pays the comissions of the operation in RBTC
      @param bucket Bucket to reedem, for example X2
      @param bproxAmount Amount in Bprox
+   */
+  function redeemBProx(bytes32 bucket, uint256 bproxAmount) public
+  whenNotPaused() whenSettlementReady() availableBucket(bucket) notBaseBucket(bucket)
+  transitionState() bucketStateTransition(bucket) {
+    redeemBProxVendors(bucket, bproxAmount, address(0));
+  }
+
+  /**
+     @dev Redeems Bprox Tokens and pays the comissions of the operation in RBTC
+     @param bucket Bucket to reedem, for example X2
+     @param bproxAmount Amount in Bprox
      @param vendorAccount Vendor address
    */
-  function redeemBProx(bytes32 bucket, uint256 bproxAmount, address vendorAccount) public
+  function redeemBProxVendors(bytes32 bucket, uint256 bproxAmount, address vendorAccount) public
   whenNotPaused() whenSettlementReady() availableBucket(bucket) notBaseBucket(bucket)
   transitionState() bucketStateTransition(bucket) {
     /** UPDATE V0110: 24/09/2020 - Upgrade to support multiple commission rates **/
@@ -219,9 +260,20 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
   * @dev BUCKET bprox minting
   * @param bucket Name of the bucket used
   * @param btcToMint amount to mint on RBTC
+  **/
+  function mintBProx(bytes32 bucket, uint256 btcToMint) public payable
+  whenNotPaused() whenSettlementReady() availableBucket(bucket) notBaseBucket(bucket)
+  transitionState() bucketStateTransition(bucket) {
+    mintBProxVendors(bucket, btcToMint, address(0));
+  }
+
+  /**
+  * @dev BUCKET bprox minting
+  * @param bucket Name of the bucket used
+  * @param btcToMint amount to mint on RBTC
   * @param vendorAccount Vendor address
   **/
-  function mintBProx(bytes32 bucket, uint256 btcToMint, address vendorAccount) public payable
+  function mintBProxVendors(bytes32 bucket, uint256 btcToMint, address vendorAccount) public payable
   whenNotPaused() whenSettlementReady() availableBucket(bucket) notBaseBucket(bucket)
   transitionState() bucketStateTransition(bucket) {
     /** UPDATE V0110: 24/09/2020 - Upgrade to support multiple commission rates **/
@@ -247,9 +299,19 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
   /**
   * @dev Redeems the requested amount for the msg.sender, or the max amount of free docs possible.
   * @param docAmount Amount of Docs to redeem.
+  */
+  function redeemFreeDoc(uint256 docAmount)
+  public
+  whenNotPaused() transitionState() notInProtectionMode() {
+    redeemFreeDocVendors(docAmount, address(0));
+  }
+
+  /**
+  * @dev Redeems the requested amount for the msg.sender, or the max amount of free docs possible.
+  * @param docAmount Amount of Docs to redeem.
   * @param vendorAccount Vendor address
   */
-  function redeemFreeDoc(uint256 docAmount, address vendorAccount)
+  function redeemFreeDocVendors(uint256 docAmount, address vendorAccount)
   public
   whenNotPaused() transitionState() notInProtectionMode() {
     /** UPDATE V0110: 24/09/2020 - Upgrade to support multiple commission rates **/
@@ -291,40 +353,40 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
     }
   }
 
-  /**
-  * @dev Calculates BitPro holders holder interest by taking the total amount of RBCs available on Bucket 0.
-  * BitPro interests = Nb (bucket 0) * bitProRate.
-  */
-  function calculateBitProHoldersInterest() public view returns(uint256, uint256) {
-    return mocInrate.calculateBitProHoldersInterest();
-  }
+  // /**
+  // * @dev Calculates BitPro holders holder interest by taking the total amount of RBCs available on Bucket 0.
+  // * BitPro interests = Nb (bucket 0) * bitProRate.
+  // */
+  // function calculateBitProHoldersInterest() public view returns(uint256, uint256) {
+  //   return mocInrate.calculateBitProHoldersInterest();
+  // }
 
-  function getBitProInterestAddress() public view returns(address payable) {
-    return mocInrate.getBitProInterestAddress();
-  }
+  // function getBitProInterestAddress() public view returns(address payable) {
+  //   return mocInrate.getBitProInterestAddress();
+  // }
 
-  function getBitProRate() public view returns(uint256) {
-    return mocInrate.getBitProRate();
-  }
+  // function getBitProRate() public view returns(uint256) {
+  //   return mocInrate.getBitProRate();
+  // }
 
-  function getBitProInterestBlockSpan() public view returns(uint256) {
-    return mocInrate.getBitProInterestBlockSpan();
-  }
+  // function getBitProInterestBlockSpan() public view returns(uint256) {
+  //   return mocInrate.getBitProInterestBlockSpan();
+  // }
 
-  function isDailyEnabled() public view returns(bool) {
-    return mocInrate.isDailyEnabled();
-  }
+  // function isDailyEnabled() public view returns(bool) {
+  //   return mocInrate.isDailyEnabled();
+  // }
 
-  function isBitProInterestEnabled() public view returns(bool) {
-    return mocInrate.isBitProInterestEnabled();
-  }
+  // function isBitProInterestEnabled() public view returns(bool) {
+  //   return mocInrate.isBitProInterestEnabled();
+  // }
 
   /**
     @dev Returns true if blockSpan number of blocks has pass since last execution
   */
-  function isSettlementEnabled() public view returns(bool) {
-    return settlement.isSettlementEnabled();
-  }
+  // function isSettlementEnabled() public view returns(bool) {
+  //   return settlement.isSettlementEnabled();
+  // }
 
   /**
    * @dev Checks if bucket liquidation is reached.

--- a/contracts/MoC.sol
+++ b/contracts/MoC.sol
@@ -70,33 +70,33 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
 
   /****************************INTERFACE*******************************************/
 
-  // function bproxBalanceOf(bytes32 bucket, address account) public view returns(uint256) {
-  //   return bproxManager.bproxBalanceOf(bucket, account);
-  // }
+  function bproxBalanceOf(bytes32 bucket, address account) public view returns(uint256) {
+    return bproxManager.bproxBalanceOf(bucket, account);
+  }
 
   /**
     @dev Gets the RedeemRequest at the queue index position
     @param index queue position to get
     @return redeemer's address and amount he submitted
   */
-  // function getRedeemRequestAt(uint256 index) public view returns(address, uint256) {
-  //   return settlement.getRedeemRequestAt(index);
-  // }
+  function getRedeemRequestAt(uint256 index) public view returns(address, uint256) {
+    return settlement.getRedeemRequestAt(index);
+  }
 
   /**
     @dev returns current redeem queue size
    */
-  // function redeemQueueSize() public view returns(uint256) {
-  //   return settlement.redeemQueueSize();
-  // }
+  function redeemQueueSize() public view returns(uint256) {
+    return settlement.redeemQueueSize();
+  }
 
   /**
     @dev returns the total amount of Docs in the redeem queue for redeemer
     @param redeemer address for which ^ is computed
    */
-  // function docAmountToRedeem(address redeemer) public view returns(uint256) {
-  //   return settlement.docAmountToRedeem(redeemer);
-  // }
+  function docAmountToRedeem(address redeemer) public view returns(uint256) {
+    return settlement.docAmountToRedeem(redeemer);
+  }
 
 
   /**
@@ -121,8 +121,7 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
     @param btcToMint Amount in BTC to mint
    */
   function mintBPro(uint256 btcToMint)
-  public payable
-  whenNotPaused() transitionState() notInProtectionMode() {
+  public payable {
     mintBProVendors(btcToMint, address(0));
   }
 
@@ -159,8 +158,7 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
      @param bproAmount Amount in Bpro
    */
   function redeemBPro(uint256 bproAmount)
-  public
-  whenNotPaused() transitionState() atLeastState(MoCState.States.AboveCobj) {
+  public {
     redeemBProVendors(bproAmount, address(0));
   }
 
@@ -190,8 +188,7 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
    * @param btcToMint Amount in RBTC to mint
    */
   function mintDoc(uint256 btcToMint)
-  public payable
-  whenNotPaused() transitionState() atLeastState(MoCState.States.AboveCobj) {
+  public payable {
     mintDocVendors(btcToMint, address(0));
   }
 
@@ -228,9 +225,7 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
      @param bucket Bucket to reedem, for example X2
      @param bproxAmount Amount in Bprox
    */
-  function redeemBProx(bytes32 bucket, uint256 bproxAmount) public
-  whenNotPaused() whenSettlementReady() availableBucket(bucket) notBaseBucket(bucket)
-  transitionState() bucketStateTransition(bucket) {
+  function redeemBProx(bytes32 bucket, uint256 bproxAmount) public {
     redeemBProxVendors(bucket, bproxAmount, address(0));
   }
 
@@ -261,9 +256,7 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
   * @param bucket Name of the bucket used
   * @param btcToMint amount to mint on RBTC
   **/
-  function mintBProx(bytes32 bucket, uint256 btcToMint) public payable
-  whenNotPaused() whenSettlementReady() availableBucket(bucket) notBaseBucket(bucket)
-  transitionState() bucketStateTransition(bucket) {
+  function mintBProx(bytes32 bucket, uint256 btcToMint) public payable {
     mintBProxVendors(bucket, btcToMint, address(0));
   }
 
@@ -301,8 +294,7 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
   * @param docAmount Amount of Docs to redeem.
   */
   function redeemFreeDoc(uint256 docAmount)
-  public
-  whenNotPaused() transitionState() notInProtectionMode() {
+  public {
     redeemFreeDocVendors(docAmount, address(0));
   }
 
@@ -353,40 +345,40 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable  {
     }
   }
 
-  // /**
-  // * @dev Calculates BitPro holders holder interest by taking the total amount of RBCs available on Bucket 0.
-  // * BitPro interests = Nb (bucket 0) * bitProRate.
-  // */
-  // function calculateBitProHoldersInterest() public view returns(uint256, uint256) {
-  //   return mocInrate.calculateBitProHoldersInterest();
-  // }
+  /**
+  * @dev Calculates BitPro holders holder interest by taking the total amount of RBCs available on Bucket 0.
+  * BitPro interests = Nb (bucket 0) * bitProRate.
+  */
+  function calculateBitProHoldersInterest() public view returns(uint256, uint256) {
+    return mocInrate.calculateBitProHoldersInterest();
+  }
 
-  // function getBitProInterestAddress() public view returns(address payable) {
-  //   return mocInrate.getBitProInterestAddress();
-  // }
+  function getBitProInterestAddress() public view returns(address payable) {
+    return mocInrate.getBitProInterestAddress();
+  }
 
-  // function getBitProRate() public view returns(uint256) {
-  //   return mocInrate.getBitProRate();
-  // }
+  function getBitProRate() public view returns(uint256) {
+    return mocInrate.getBitProRate();
+  }
 
-  // function getBitProInterestBlockSpan() public view returns(uint256) {
-  //   return mocInrate.getBitProInterestBlockSpan();
-  // }
+  function getBitProInterestBlockSpan() public view returns(uint256) {
+    return mocInrate.getBitProInterestBlockSpan();
+  }
 
-  // function isDailyEnabled() public view returns(bool) {
-  //   return mocInrate.isDailyEnabled();
-  // }
+  function isDailyEnabled() public view returns(bool) {
+    return mocInrate.isDailyEnabled();
+  }
 
-  // function isBitProInterestEnabled() public view returns(bool) {
-  //   return mocInrate.isBitProInterestEnabled();
-  // }
+  function isBitProInterestEnabled() public view returns(bool) {
+    return mocInrate.isBitProInterestEnabled();
+  }
 
   /**
     @dev Returns true if blockSpan number of blocks has pass since last execution
   */
-  // function isSettlementEnabled() public view returns(bool) {
-  //   return settlement.isSettlementEnabled();
-  // }
+  function isSettlementEnabled() public view returns(bool) {
+    return settlement.isSettlementEnabled();
+  }
 
   /**
    * @dev Checks if bucket liquidation is reached.

--- a/contracts/test-contracts/RevertingOnSend.sol
+++ b/contracts/test-contracts/RevertingOnSend.sol
@@ -20,11 +20,11 @@ contract RevertingOnSend {
   }
 
   function mintBProx(bytes32 bucket, uint256 bproxAmountToMint, address vendorAccount) public payable {
-    moc.mintBProx.value(msg.value)(bucket, bproxAmountToMint, vendorAccount);
+    moc.mintBProxVendors.value(msg.value)(bucket, bproxAmountToMint, vendorAccount);
   }
 
   function mintDoc(uint256 docAmountToMint, address vendorAccount) public payable {
-    moc.mintDoc.value(msg.value)(docAmountToMint, vendorAccount);
+    moc.mintDocVendors.value(msg.value)(docAmountToMint, vendorAccount);
   }
 
   function redeemDoCRequest(uint256 docAmount) public {

--- a/test/moc/MoCBProMinting-test.js
+++ b/test/moc/MoCBProMinting-test.js
@@ -91,11 +91,7 @@ contract('MoC: MoCExchange', function([owner, userAccount, vendorAccount]) {
       let maxBPro;
       const from = userAccount;
       beforeEach(async function() {
-        const rbtcToMintBpro = toContractBN(11 * mocHelper.RESERVE_PRECISION);
-        await this.moc.mintBPro(rbtcToMintBpro, vendorAccount, {
-          from,
-          value: rbtcToMintBpro
-        });
+        await mocHelper.mintBPro(from, 11, vendorAccount);
         c0PrevBProBalance = await this.mocState.getBucketNBPro(BUCKET_C0);
         c0PrevBTCBalance = await this.mocState.getBucketNBTC(BUCKET_C0);
         initialBProBalance = await mocHelper.getBProBalance(userAccount);

--- a/test/moc/MoCBProxRedemption-test.js
+++ b/test/moc/MoCBProxRedemption-test.js
@@ -157,22 +157,7 @@ contract('MoC : MoCExchange', function([owner, userAccount, vendorAccount]) {
           ({ params } = await mocHelper.getContractReadyState(s));
           await mocHelper.setBitcoinPrice(params.btcPrice);
 
-          // TODO: This function should be called via the mocHelper and not directly.
-          // We need to understand why the precision is not helping.
-          // tx = await mocHelper.redeemBProx(
-          //   userAccount,
-          //   BUCKET_X2,
-          //   toContractBN(params.nBProx),
-          //   vendorAccount
-          // );
-          tx = await this.moc.redeemBProxVendors(
-            BUCKET_X2,
-            toContractBN(params.nBProx),
-            vendorAccount,
-            {
-              from: userAccount
-            }
-          );
+          tx = await mocHelper.redeemBProx(userAccount, BUCKET_X2, s.params.nBProx, vendorAccount);
 
           finalRbtcBalance = toContractBN(await web3.eth.getBalance(userAccount));
           txCost = await mocHelper.getTxCost(tx);

--- a/test/moc/MoCBProxRedemption-test.js
+++ b/test/moc/MoCBProxRedemption-test.js
@@ -157,9 +157,22 @@ contract('MoC : MoCExchange', function([owner, userAccount, vendorAccount]) {
           ({ params } = await mocHelper.getContractReadyState(s));
           await mocHelper.setBitcoinPrice(params.btcPrice);
 
-          tx = await this.moc.redeemBProx(BUCKET_X2, toContractBN(params.nBProx), vendorAccount, {
-            from: userAccount
-          });
+          // TODO: This function should be called via the mocHelper and not directly.
+          // We need to understand why the precision is not helping.
+          // tx = await mocHelper.redeemBProx(
+          //   userAccount,
+          //   BUCKET_X2,
+          //   toContractBN(params.nBProx),
+          //   vendorAccount
+          // );
+          tx = await this.moc.redeemBProxVendors(
+            BUCKET_X2,
+            toContractBN(params.nBProx),
+            vendorAccount,
+            {
+              from: userAccount
+            }
+          );
 
           finalRbtcBalance = toContractBN(await web3.eth.getBalance(userAccount));
           txCost = await mocHelper.getTxCost(tx);

--- a/test/moc/MoCBProxSeqMinting-test.js
+++ b/test/moc/MoCBProxSeqMinting-test.js
@@ -35,10 +35,7 @@ contract('MoC', function([owner, vendorAccount]) {
           // Max at the start
           const lastBtcMax = await this.mocState.maxBProxBtcValue(BUCKET_X2);
           // First minting
-          await this.moc.mintBProx(BUCKET_X2, btcTotal, vendorAccount, {
-            from: userAccount,
-            value: btcTotal
-          });
+          await mocHelper.mintBProx(userAccount, BUCKET_X2, nB, vendorAccount, nB);
 
           const newBtcMax = await this.mocState.maxBProxBtcValue(BUCKET_X2);
 

--- a/test/moc/MoCBProxTracker-test.js
+++ b/test/moc/MoCBProxTracker-test.js
@@ -35,7 +35,7 @@ contract('MoCBProxManager: BProx Address tracking ', function([
     beforeEach(async function() {
       await mocHelper.mintBProAmount(owner, 30, vendorAccount);
       await mocHelper.mintDocAmount(owner, 50000, vendorAccount);
-      await mocHelper.mintBProx(account1, vendorAccount, BUCKET_X2, 1);
+      await mocHelper.mintBProx(account1, BUCKET_X2, 1, vendorAccount);
     });
     it('THEN he enters the address tracker', async function() {
       const activeAddress = await this.bprox.getActiveAddresses(BUCKET_X2);
@@ -49,7 +49,7 @@ contract('MoCBProxManager: BProx Address tracking ', function([
     });
     describe('AND another account also mints', function() {
       beforeEach(async function() {
-        await mocHelper.mintBProx(account2, vendorAccount, BUCKET_X2, 1);
+        await mocHelper.mintBProx(account2, BUCKET_X2, 1, vendorAccount);
       });
       it('THEN both get tracked', async function() {
         const activeAddress = await this.bprox.getActiveAddresses(BUCKET_X2);
@@ -76,7 +76,7 @@ contract('MoCBProxManager: BProx Address tracking ', function([
         });
         describe('AND a third user mints', function() {
           it('THEN tracker length is two and third user is tracked', async function() {
-            await mocHelper.mintBProx(account3, vendorAccount, BUCKET_X2, 1);
+            await mocHelper.mintBProx(account3, BUCKET_X2, 1, vendorAccount);
             const activeAddress = await this.bprox.getActiveAddresses(BUCKET_X2);
             const activeAddressLength = await this.bprox.getActiveAddressesCount(BUCKET_X2);
             assert.equal(activeAddressLength, 2, 'length should be two');
@@ -85,7 +85,7 @@ contract('MoCBProxManager: BProx Address tracking ', function([
         });
         describe('AND account1 mints again', function() {
           it('THEN tracker length is two and owner is last', async function() {
-            await mocHelper.mintBProx(account1, vendorAccount, BUCKET_X2, 1);
+            await mocHelper.mintBProx(account1, BUCKET_X2, 1, vendorAccount);
             const activeAddress = await this.bprox.getActiveAddresses(BUCKET_X2);
             const activeAddressLength = await this.bprox.getActiveAddressesCount(BUCKET_X2);
             assert.equal(activeAddressLength, 2, 'length should be two');

--- a/test/moc/MoCBProxTracker-test.js
+++ b/test/moc/MoCBProxTracker-test.js
@@ -59,13 +59,11 @@ contract('MoCBProxManager: BProx Address tracking ', function([
       });
       describe('WHEN account 1 liquidates his entire position', function() {
         beforeEach(async function() {
-          await this.moc.redeemBProx(
+          await mocHelper.redeemBProx(
+            account1,
             BUCKET_X2,
             toContractBN(1 * mocHelper.RESERVE_PRECISION),
-            vendorAccount,
-            {
-              from: account1
-            }
+            vendorAccount
           );
         });
         it('THEN tracker shrinks', async function() {
@@ -95,11 +93,7 @@ contract('MoCBProxManager: BProx Address tracking ', function([
       });
       describe('WHEN account 1 partially liquidates his position', function() {
         it('THEN tracker remains the same', async function() {
-          await this.moc.redeemBProx(
-            BUCKET_X2,
-            toContractBN(0.5 * mocHelper.RESERVE_PRECISION),
-            vendorAccount
-          );
+          await mocHelper.redeemBProx(account1, BUCKET_X2, 0.5, vendorAccount);
           const activeAddress = await this.bprox.getActiveAddresses(BUCKET_X2);
           const activeAddressLength = await this.bprox.getActiveAddressesCount(BUCKET_X2);
           assert.equal(activeAddressLength, 2, 'length should be unchanged');

--- a/test/moc/MoCBProxTracker-test.js
+++ b/test/moc/MoCBProxTracker-test.js
@@ -1,7 +1,6 @@
 const testHelperBuilder = require('../mocHelper.js');
 
 let mocHelper;
-// let toContractBN;
 let BUCKET_X2;
 
 contract('MoCBProxManager: BProx Address tracking ', function([
@@ -13,7 +12,6 @@ contract('MoCBProxManager: BProx Address tracking ', function([
 ]) {
   before(async function() {
     mocHelper = await testHelperBuilder({ owner });
-    // ({ toContractBN } = mocHelper);
     ({ BUCKET_X2 } = mocHelper);
     this.moc = mocHelper.moc;
     this.bprox = mocHelper.bprox;

--- a/test/moc/MoCBProxTracker-test.js
+++ b/test/moc/MoCBProxTracker-test.js
@@ -1,7 +1,7 @@
 const testHelperBuilder = require('../mocHelper.js');
 
 let mocHelper;
-let toContractBN;
+// let toContractBN;
 let BUCKET_X2;
 
 contract('MoCBProxManager: BProx Address tracking ', function([
@@ -13,7 +13,7 @@ contract('MoCBProxManager: BProx Address tracking ', function([
 ]) {
   before(async function() {
     mocHelper = await testHelperBuilder({ owner });
-    ({ toContractBN } = mocHelper);
+    // ({ toContractBN } = mocHelper);
     ({ BUCKET_X2 } = mocHelper);
     this.moc = mocHelper.moc;
     this.bprox = mocHelper.bprox;
@@ -59,12 +59,7 @@ contract('MoCBProxManager: BProx Address tracking ', function([
       });
       describe('WHEN account 1 liquidates his entire position', function() {
         beforeEach(async function() {
-          await mocHelper.redeemBProx(
-            account1,
-            BUCKET_X2,
-            toContractBN(1 * mocHelper.RESERVE_PRECISION),
-            vendorAccount
-          );
+          await mocHelper.redeemBProx(account1, BUCKET_X2, 1, vendorAccount);
         });
         it('THEN tracker shrinks', async function() {
           const activeAddress = await this.bprox.getActiveAddresses(BUCKET_X2);

--- a/test/moc/MoCBproxGlobalIndicators-test.js
+++ b/test/moc/MoCBproxGlobalIndicators-test.js
@@ -55,12 +55,7 @@ contract('MoC : BTCx operations does not modify global indicators', function([
       [1, 3, 5].forEach(redValue => {
         describe(`AND user redeems ${redValue}`, function() {
           beforeEach(async function() {
-            await mocHelper.redeemBProx(
-              userAccount,
-              BUCKET_X2,
-              toContractBN(redValue * mocHelper.RESERVE_PRECISION),
-              vendorAccount
-            );
+            await mocHelper.redeemBProx(userAccount, BUCKET_X2, redValue, vendorAccount);
           });
           it('THEN global indicators should not change', async function() {
             const finalCoverage = await this.mocState.globalCoverage();

--- a/test/moc/MoCBproxGlobalIndicators-test.js
+++ b/test/moc/MoCBproxGlobalIndicators-test.js
@@ -55,13 +55,11 @@ contract('MoC : BTCx operations does not modify global indicators', function([
       [1, 3, 5].forEach(redValue => {
         describe(`AND user redeems ${redValue}`, function() {
           beforeEach(async function() {
-            await this.moc.redeemBProx(
+            await mocHelper.redeemBProx(
+              userAccount,
               BUCKET_X2,
               toContractBN(redValue * mocHelper.RESERVE_PRECISION),
-              vendorAccount,
-              {
-                from: userAccount
-              }
+              vendorAccount
             );
           });
           it('THEN global indicators should not change', async function() {

--- a/test/moc/MoCFreeDocs-test.js
+++ b/test/moc/MoCFreeDocs-test.js
@@ -196,13 +196,11 @@ contract.skip('MoC', function([owner, userAccount, otherAccount, vendorAccount])
             describe(`AND ${scenario.params.docsToRedeem} docs are redeemed`, function() {
               beforeEach(async function() {
                 userBtcBalance = await web3.eth.getBalance(userAccount);
-                redeemTx = await this.moc.redeemFreeDoc(
-                  toContractBN(scenario.params.docsToRedeem * mocHelper.MOC_PRECISION),
-                  vendorAccount,
-                  {
-                    from: userAccount
-                  }
-                );
+                redeemTx = await mocHelper.redeemFreeDoc({
+                  userAccount,
+                  docAmount: scenario.params.docsToRedeem,
+                  vendorAccount
+                });
                 usedGas = toContractBN(await mocHelper.getTxCost(redeemTx));
               });
               it(`THEN the redeemers BTC balance is increased by redeeming only ${scenario.expect.docsToRedeem} docs`, async function() {
@@ -422,13 +420,11 @@ contract.skip('MoC', function([owner, userAccount, otherAccount, vendorAccount])
               describe(`AND ${scenario.params.docsToRedeem} docs are redeemed`, function() {
                 beforeEach(async function() {
                   userBtcBalance = toContractBN(await web3.eth.getBalance(userAccount));
-                  redeemTx = await this.moc.redeemFreeDoc(
-                    toContractBN(scenario.params.docsToRedeem * mocHelper.RESERVE_PRECISION),
-                    vendorAccount,
-                    {
-                      from: userAccount
-                    }
-                  );
+                  redeemTx = await mocHelper.redeemFreeDoc({
+                    userAccount,
+                    docAmount: scenario.params.docsToRedeem,
+                    vendorAccount
+                  });
                   usedGas = await mocHelper.getTxCost(redeemTx);
                 });
                 it(`THEN the redeemers BTC balance is increased by redeeming only ${scenario.expect.docsToRedeem} docs`, async function() {

--- a/test/moc/MoCInterests-test.js
+++ b/test/moc/MoCInterests-test.js
@@ -159,9 +159,10 @@ contract('MoC : MoCExchange', function([owner, userAccount, vendorAccount]) {
           await this.mocState.setDaysToSettlement(toContractBN(2, 'DAY'));
           ({ params } = mocHelper.getContractReadyState(s));
           await mocHelper.mintBProxAmount(userAccount, BUCKET_X2, 5, vendorAccount);
-
-          await this.moc.redeemFreeDoc(toContractBN(params.freeDocRedeem.nDoCs), vendorAccount, {
-            from: userAccount
+          await mocHelper.redeemFreeDoc({
+            userAccount,
+            docAmount: params.freeDocRedeem.nDoCs,
+            vendorAccount
           });
         });
         it(`THEN inrate should be ${s.expect.inrate}`, async function() {

--- a/test/moc/MoCInterestsRecovery-test.js
+++ b/test/moc/MoCInterestsRecovery-test.js
@@ -41,7 +41,7 @@ contract('MoC : MoCExchange', function([owner, userAccount, vendorAccount]) {
             true
           );
 
-          const mintTx = await mocHelper.mintBProx(userAccount, vendorAccount, BUCKET_X2, 5);
+          const mintTx = await mocHelper.mintBProx(userAccount, BUCKET_X2, 5, vendorAccount);
           [mintEvent] = mocHelper.findEvents(mintTx, 'RiskProxMint');
         });
         it('THEN the interest taken includes all days to settlement', function() {

--- a/test/moc/MoCInterestsRecovery-test.js
+++ b/test/moc/MoCInterestsRecovery-test.js
@@ -61,12 +61,7 @@ contract('MoC : MoCExchange', function([owner, userAccount, vendorAccount]) {
               mintEvent.reserveTotal,
               false
             );
-            const redeemTx = await mocHelper.redeemBProx(
-              userAccount,
-              BUCKET_X2,
-              toContractBN(5, 'BTC'),
-              vendorAccount
-            );
+            const redeemTx = await mocHelper.redeemBProx(userAccount, BUCKET_X2, 5, vendorAccount);
 
             [redeemEvent] = mocHelper.findEvents(redeemTx, 'RiskProxRedeem');
           });

--- a/test/moc/MoCInterestsRecovery-test.js
+++ b/test/moc/MoCInterestsRecovery-test.js
@@ -61,13 +61,11 @@ contract('MoC : MoCExchange', function([owner, userAccount, vendorAccount]) {
               mintEvent.reserveTotal,
               false
             );
-            const redeemTx = await this.moc.redeemBProx(
+            const redeemTx = await mocHelper.redeemBProx(
+              userAccount,
               BUCKET_X2,
               toContractBN(5, 'BTC'),
-              vendorAccount,
-              {
-                from: userAccount
-              }
+              vendorAccount
             );
 
             [redeemEvent] = mocHelper.findEvents(redeemTx, 'RiskProxRedeem');

--- a/test/moc/MoCPaused-test.js
+++ b/test/moc/MoCPaused-test.js
@@ -14,7 +14,7 @@ const assertAllMintReedemMocHelperPausedFunctions = (userAccount, vendorAccount)
     { name: 'mintDoc', args: [userAccount, 10000, vendorAccount] },
     {
       name: 'mintBProx',
-      args: [userAccount, vendorAccount, BUCKET_X2, toContractBN(10), toContractBN(9000)]
+      args: [userAccount, BUCKET_X2, toContractBN(10), vendorAccount, toContractBN(9000)]
     },
     { name: 'redeemFreeDoc', args: [{ userAccount, docAmount: 3, vendorAccount }] },
     { name: 'redeemBPro', args: [userAccount, 10, vendorAccount] }
@@ -28,7 +28,7 @@ const assertAllMintReedemMocHelperPausedFunctions = (userAccount, vendorAccount)
 
 const assertAllMocPausedFunctions = (owner, userAccount, vendorAccount) => {
   const testFunctions = [
-    { name: 'redeemBProx', args: [BUCKET_X2, 3, vendorAccount] },
+    { name: 'redeemBProxVendors', args: [BUCKET_X2, 3, vendorAccount] },
     { name: 'alterRedeemRequestAmount', args: [false, 100] },
     { name: 'runSettlement', args: [1] },
     { name: 'dailyInratePayment', args: [{ from: owner }] },

--- a/test/moc/MoCRetrocompatibility-test.js
+++ b/test/moc/MoCRetrocompatibility-test.js
@@ -5,15 +5,10 @@ const { BN } = web3.utils;
 let mocHelper;
 let BUCKET_X2;
 
-contract('MoC: Retrocompatibility', function([
-  owner,
-  userAccount,
-  commissionsAccount,
-  otherAddress
-]) {
+contract('MoC: Retrocompatibility', function([owner, userAccount]) {
   before(async function() {
     mocHelper = await testHelperBuilder({ owner });
-    ({ toContractBN, BUCKET_X2 } = mocHelper);
+    ({ BUCKET_X2 } = mocHelper);
     this.moc = mocHelper.moc;
     this.mockMocInrateChanger = mocHelper.mockMocInrateChanger;
     this.governor = mocHelper.governor;

--- a/test/moc/MoCRetrocompatibility-test.js
+++ b/test/moc/MoCRetrocompatibility-test.js
@@ -1,8 +1,11 @@
 const testHelperBuilder = require('../mocHelper.js');
 
-let mocHelper;
+const { BN } = web3.utils;
 
-contract.only('MoC: Retrocompatibility', function([
+let mocHelper;
+let BUCKET_X2;
+
+contract('MoC: Retrocompatibility', function([
   owner,
   userAccount,
   commissionsAccount,
@@ -10,12 +13,13 @@ contract.only('MoC: Retrocompatibility', function([
 ]) {
   before(async function() {
     mocHelper = await testHelperBuilder({ owner });
-    ({ toContractBN } = mocHelper);
+    ({ toContractBN, BUCKET_X2 } = mocHelper);
     this.moc = mocHelper.moc;
     this.mockMocInrateChanger = mocHelper.mockMocInrateChanger;
     this.governor = mocHelper.governor;
     this.mocState = mocHelper.mocState;
     this.btcPrice = await this.mocState.getBitcoinPrice();
+    this.bprox2Price = await this.mocState.bucketBProTecPrice(BUCKET_X2);
   });
 
   beforeEach(async function() {
@@ -36,57 +40,78 @@ contract.only('MoC: Retrocompatibility', function([
       const mintAmount = 100;
 
       // Mint
-      await mocHelper.mintBPro(
-        userAccount,
-        mintAmount
-      );
+      await mocHelper.mintBPro(userAccount, mintAmount);
       const balance = await mocHelper.getBProBalance(userAccount);
       mocHelper.assertBigRBTC(balance, mintAmount, 'userAccount BPro balance was not mintAmount');
     });
     it('WHEN a user tries to redeem BPros, THEN operation is successful', async function() {
       const redeemAmount = 100;
 
-      // Mint
-      await mocHelper.redeemBPro(
-        userAccount,
-        redeemAmount
-      );
+      // Redeem
+      await mocHelper.redeemBPro(userAccount, redeemAmount);
       const balance = await mocHelper.getBProBalance(userAccount);
       mocHelper.assertBigRBTC(balance, 0, 'userAccount BPro balance was not 0');
     });
   });
   describe('GIVEN since the user wants to mint and redeem DOC with the retrocompatible functions', function() {
     it('WHEN a user tries to mint DOCs, THEN operation is successful', async function() {
-
-      // Mint BPros
-      await mocHelper.mintBPro(
-        userAccount,
-        100
-      );
+      // Mint BPros to be able to mint DoC
+      await mocHelper.mintBPro(userAccount, 100);
 
       const mintAmount = 1;
 
       // Mint
-      await mocHelper.mintDoC(
-        userAccount,
-        mintAmount
-      );
+      await mocHelper.mintDoc(userAccount, mintAmount);
       const balance = await mocHelper.getDoCBalance(userAccount);
-      const mintAmountInDoC = mintAmount.mul(this.btcPrice).div(mocHelper.RESERVE_PRECISION);
-      mocHelper.assertBigRBTC(balance, mintAmountInDoC, 'userAccount DoC balance was not mintAmountInDoC');
+      const mintAmountInDoC = new BN(mintAmount)
+        .mul(this.btcPrice)
+        .div(mocHelper.RESERVE_PRECISION);
+      mocHelper.assertBigRBTC(
+        balance,
+        mintAmountInDoC,
+        'userAccount DoC balance was not mintAmountInDoC'
+      );
     });
     it('WHEN a user tries to redeem DOCs, THEN operation is successful', async function() {
-
       const redeemAmount = 1;
 
-      // Mint
-      await mocHelper.redeemDoC(
+      // Redeem
+      await mocHelper.redeemFreeDoc({
         userAccount,
-        redeemAmount
-      );
+        docAmount: redeemAmount
+      });
       const balance = await mocHelper.getDoCBalance(userAccount);
-      const redeemAmountInDoC = redeemAmount.mul(this.btcPrice).div(mocHelper.RESERVE_PRECISION);
-      mocHelper.assertBigRBTC(balance, redeemAmountInDoC, 'userAccount DoC balance was not mintAmountInDoC');
+      mocHelper.assertBigRBTC(balance, 0, 'userAccount DoC balance was not 0');
+    });
+  });
+  describe('GIVEN since the user wants to mint and redeem BPROX with the retrocompatible functions', function() {
+    it('WHEN a user tries to mint BPROXs, THEN operation is successful', async function() {
+      // Mint BPros to be able to mint DoC
+      await mocHelper.mintBPro(userAccount, 100);
+      // Mint DOCs to be able to mint BTCX
+      await mocHelper.mintDoc(userAccount, 100);
+
+      const mintAmount = 1;
+
+      // Mint
+      await mocHelper.mintBProx(userAccount, BUCKET_X2, mintAmount);
+      const balance = await mocHelper.getBProxBalance(BUCKET_X2, userAccount);
+      const mintAmountInBTCX = new BN(mintAmount)
+        .mul(mocHelper.MOC_PRECISION)
+        .div(this.bprox2Price);
+      mocHelper.assertBigRBTC(
+        balance,
+        mintAmountInBTCX,
+        'userAccount BPROX balance was not mintAmountInBTCX'
+      );
+    });
+    it('WHEN a user tries to redeem BPROXs, THEN operation is successful', async function() {
+      const redeemAmount = 1;
+
+      // Redeem
+      await mocHelper.redeemBProx(userAccount, BUCKET_X2, redeemAmount);
+      const balance = await mocHelper.getBProxBalance(BUCKET_X2, userAccount);
+      mocHelper.assertBigRBTC(balance, 0, 'userAccount BPROX balance was not 0');
     });
   });
 });

--- a/test/moc/MoCRetrocompatibility-test.js
+++ b/test/moc/MoCRetrocompatibility-test.js
@@ -1,0 +1,92 @@
+const testHelperBuilder = require('../mocHelper.js');
+
+let mocHelper;
+
+contract.only('MoC: Retrocompatibility', function([
+  owner,
+  userAccount,
+  commissionsAccount,
+  otherAddress
+]) {
+  before(async function() {
+    mocHelper = await testHelperBuilder({ owner });
+    ({ toContractBN } = mocHelper);
+    this.moc = mocHelper.moc;
+    this.mockMocInrateChanger = mocHelper.mockMocInrateChanger;
+    this.governor = mocHelper.governor;
+    this.mocState = mocHelper.mocState;
+    this.btcPrice = await this.mocState.getBitcoinPrice();
+  });
+
+  beforeEach(async function() {
+    await mocHelper.revertState();
+    // Commission rates for test are set in functionHelper.js
+    // await mocHelper.mockMocInrateChanger.setCommissionRates(
+    //   await mocHelper.getCommissionsArrayNonZero()
+    // );
+
+    // // set commissions address
+    // await mocHelper.mockMocInrateChanger.setCommissionsAddress(commissionsAccount);
+    // // update params
+    // await mocHelper.governor.executeChange(mocHelper.mockMocInrateChanger.address);
+  });
+
+  describe('GIVEN since the user wants to mint and redeem BPro with the retrocompatible functions', function() {
+    it('WHEN a user tries to mint BPros, THEN operation is successful', async function() {
+      const mintAmount = 100;
+
+      // Mint
+      await mocHelper.mintBPro(
+        userAccount,
+        mintAmount
+      );
+      const balance = await mocHelper.getBProBalance(userAccount);
+      mocHelper.assertBigRBTC(balance, mintAmount, 'userAccount BPro balance was not mintAmount');
+    });
+    it('WHEN a user tries to redeem BPros, THEN operation is successful', async function() {
+      const redeemAmount = 100;
+
+      // Mint
+      await mocHelper.redeemBPro(
+        userAccount,
+        redeemAmount
+      );
+      const balance = await mocHelper.getBProBalance(userAccount);
+      mocHelper.assertBigRBTC(balance, 0, 'userAccount BPro balance was not 0');
+    });
+  });
+  describe('GIVEN since the user wants to mint and redeem DOC with the retrocompatible functions', function() {
+    it('WHEN a user tries to mint DOCs, THEN operation is successful', async function() {
+
+      // Mint BPros
+      await mocHelper.mintBPro(
+        userAccount,
+        100
+      );
+
+      const mintAmount = 1;
+
+      // Mint
+      await mocHelper.mintDoC(
+        userAccount,
+        mintAmount
+      );
+      const balance = await mocHelper.getDoCBalance(userAccount);
+      const mintAmountInDoC = mintAmount.mul(this.btcPrice).div(mocHelper.RESERVE_PRECISION);
+      mocHelper.assertBigRBTC(balance, mintAmountInDoC, 'userAccount DoC balance was not mintAmountInDoC');
+    });
+    it('WHEN a user tries to redeem DOCs, THEN operation is successful', async function() {
+
+      const redeemAmount = 1;
+
+      // Mint
+      await mocHelper.redeemDoC(
+        userAccount,
+        redeemAmount
+      );
+      const balance = await mocHelper.getDoCBalance(userAccount);
+      const redeemAmountInDoC = redeemAmount.mul(this.btcPrice).div(mocHelper.RESERVE_PRECISION);
+      mocHelper.assertBigRBTC(balance, redeemAmountInDoC, 'userAccount DoC balance was not mintAmountInDoC');
+    });
+  });
+});

--- a/test/moc/MoCState-test.js
+++ b/test/moc/MoCState-test.js
@@ -1,12 +1,12 @@
 const testHelperBuilder = require('../mocHelper.js');
 
 let mocHelper;
-let toContractBN;
+// let toContractBN;
 const BUCKET_C0 = web3.utils.asciiToHex('C0', 32);
 contract('MoC', function([owner, vendorAccount]) {
   before(async function() {
     mocHelper = await testHelperBuilder({ owner });
-    ({ toContractBN } = mocHelper);
+    // ({ toContractBN } = mocHelper);
     this.mocState = mocHelper.mocState;
     this.moc = mocHelper.moc;
     this.governor = mocHelper.governor;
@@ -155,24 +155,12 @@ contract('MoC', function([owner, vendorAccount]) {
               // It will be always the middle between the two values.
               await mocHelper.setSmoothingFactor(0.5 * 10 ** 18);
 
-              if (contractReadyState.nDoCs) {
-                await this.moc.mintDoc(
-                  toContractBN(contractReadyState.nDocsBtcAmount),
-                  vendorAccount,
-                  {
-                    value: toContractBN(contractReadyState.nDocsBtcAmount)
-                  }
-                );
+              if (state.nDoCs) {
+                await mocHelper.mintDoc(owner, state.nDocsBtcAmount, vendorAccount);
               }
 
-              if (contractReadyState.nBPro) {
-                await this.moc.mintBPro(
-                  toContractBN(contractReadyState.bproBtcAmount),
-                  vendorAccount,
-                  {
-                    value: toContractBN(contractReadyState.bproBtcAmount)
-                  }
-                );
+              if (state.nBPro) {
+                await mocHelper.mintBPro(owner, state.bproBtcAmount, vendorAccount);
               }
 
               await mocHelper.setBitcoinPrice(contractReadyState.btcPrice.to);

--- a/test/moc/MoCState-test.js
+++ b/test/moc/MoCState-test.js
@@ -1,12 +1,11 @@
 const testHelperBuilder = require('../mocHelper.js');
 
 let mocHelper;
-// let toContractBN;
+
 const BUCKET_C0 = web3.utils.asciiToHex('C0', 32);
 contract('MoC', function([owner, vendorAccount]) {
   before(async function() {
     mocHelper = await testHelperBuilder({ owner });
-    // ({ toContractBN } = mocHelper);
     this.mocState = mocHelper.mocState;
     this.moc = mocHelper.moc;
     this.governor = mocHelper.governor;

--- a/test/moc/MocBProxFullRedemption-test.js
+++ b/test/moc/MocBProxFullRedemption-test.js
@@ -136,9 +136,12 @@ contract('MoC: RedeemBProx', function([owner, vendorAccount, ...accounts]) {
                 await mocHelper.setBitcoinPrice(user.btcPrice * mocHelper.MOC_PRECISION);
               }
 
-              await this.moc.redeemBProx(BUCKET_X2, userBProxBalance, vendorAccount, {
-                from: accounts[index + 1]
-              });
+              await mocHelper.redeemBProx(
+                accounts[index + 1],
+                BUCKET_X2,
+                userBProxBalance,
+                vendorAccount
+              );
 
               if (index === s.users.length - 1) resolve();
             });

--- a/test/moc/MocBProxFullRedemption-test.js
+++ b/test/moc/MocBProxFullRedemption-test.js
@@ -118,7 +118,7 @@ contract('MoC: RedeemBProx', function([owner, vendorAccount, ...accounts]) {
 
             await mocHelper.mintBProAmount(account, user.nBPro, vendorAccount);
             await mocHelper.mintDocAmount(account, user.nDoc, vendorAccount);
-            await mocHelper.mintBProx(account, vendorAccount, BUCKET_X2, user.bproxMint.nB);
+            await mocHelper.mintBProx(account, BUCKET_X2, user.bproxMint.nB, vendorAccount);
             if (index === s.users.length - 1) resolve();
           });
         });

--- a/test/moc/commissions/MoCBProxRedemptionWithCommissions-test.js
+++ b/test/moc/commissions/MoCBProxRedemptionWithCommissions-test.js
@@ -209,13 +209,11 @@ contract('MoC', function([owner, userAccount, commissionsAccount, vendorAccount,
             prevVendorAccountBtcBalance = toContractBN(await web3.eth.getBalance(vendorAccount));
             prevVendorAccountMoCBalance = await mocHelper.getMoCBalance(vendorAccount);
 
-            const redeemTx = await this.moc.redeemBProx(
+            const redeemTx = await mocHelper.redeemBProx(
+              userAccount,
               BUCKET_X2,
-              toContractBN(scenario.params.bproxsToRedeem * mocHelper.RESERVE_PRECISION),
-              vendorAccount,
-              {
-                from: userAccount
-              }
+              scenario.params.bproxsToRedeem,
+              vendorAccount
             );
             usedGas = await mocHelper.getTxCost(redeemTx);
           });
@@ -335,13 +333,11 @@ contract('MoC', function([owner, userAccount, commissionsAccount, vendorAccount,
           await mocHelper.approveMoCToken(mocHelper.moc.address, mocAmountToApprove, userAccount);
           const prevUserMoCBalance = await mocHelper.getMoCBalance(userAccount);
           const prevUserBtcBalance = toContractBN(await web3.eth.getBalance(userAccount));
-          const tx = await this.moc.redeemBProx(
+          const tx = await mocHelper.redeemBProx(
+            userAccount,
             BUCKET_X2,
             toContractBN(10 * mocHelper.RESERVE_PRECISION),
-            vendorAccount,
-            {
-              from: userAccount
-            }
+            vendorAccount
           );
           const userMoCBalance = await mocHelper.getMoCBalance(userAccount);
           const diffMoC = prevUserMoCBalance.sub(userMoCBalance);
@@ -391,13 +387,11 @@ contract('MoC', function([owner, userAccount, commissionsAccount, vendorAccount,
           const prevUserMoCBalance = await mocHelper.getMoCBalance(otherAddress);
 
           // Redeem
-          await this.moc.redeemBProx(
+          await mocHelper.redeemBProx(
+            otherAddress,
             BUCKET_X2,
             toContractBN(bproxsToRedeem * mocHelper.RESERVE_PRECISION),
-            vendorAccount,
-            {
-              from: otherAddress
-            }
+            vendorAccount
           );
 
           const userMoCBalance = await mocHelper.getMoCBalance(otherAddress);
@@ -432,13 +426,11 @@ contract('MoC', function([owner, userAccount, commissionsAccount, vendorAccount,
           try {
             await mocHelper.mintMoCToken(failingAddress, 0, owner);
             await mocHelper.approveMoCToken(mocHelper.moc.address, 0, failingAddress);
-            const tx = await this.moc.redeemBProx(
+            const tx = await mocHelper.redeemBProx(
+              userAccount,
               BUCKET_X2,
               toContractBN(10 * mocHelper.RESERVE_PRECISION),
-              vendorAccount,
-              {
-                from: userAccount
-              }
+              vendorAccount
             );
             assert(tx === null, 'This should not happen');
           } catch (err) {
@@ -490,13 +482,11 @@ contract('MoC', function([owner, userAccount, commissionsAccount, vendorAccount,
           const prevUserMoCBalance = await mocHelper.getMoCBalance(otherAddress);
 
           // Redeem
-          await this.moc.redeemBProx(
+          await mocHelper.redeemBProx(
+            otherAddress,
             BUCKET_X2,
             toContractBN(bproxsToRedeem * mocHelper.RESERVE_PRECISION),
-            vendorAccount,
-            {
-              from: otherAddress
-            }
+            vendorAccount
           );
 
           const userMoCBalance = await mocHelper.getMoCBalance(otherAddress);
@@ -581,13 +571,11 @@ contract('MoC', function([owner, userAccount, commissionsAccount, vendorAccount,
           prevCommissionsAccountMoCBalance = await mocHelper.getMoCBalance(commissionsAccount);
           prevVendorAccountMoCBalance = await mocHelper.getMoCBalance(vendorAccount);
 
-          const redeemTx = await this.moc.redeemBProx(
+          const redeemTx = await mocHelper.redeemBProx(
+            userAccount,
             BUCKET_X2,
-            toContractBN(bproxsToRedeem * mocHelper.RESERVE_PRECISION),
-            vendorAccount,
-            {
-              from: userAccount
-            }
+            bproxsToRedeem,
+            vendorAccount
           );
           usedGas = await mocHelper.getTxCost(redeemTx);
         });

--- a/test/moc/commissions/MoCBProxRedemptionWithCommissions-test.js
+++ b/test/moc/commissions/MoCBProxRedemptionWithCommissions-test.js
@@ -8,13 +8,7 @@ let BUCKET_X2;
 const NOT_ENOUGH_FUNDS_ERROR = "sender doesn't have enough funds to send tx";
 
 // TODO: test BProx redeems with interests
-contract.only('MoC', function([
-  owner,
-  userAccount,
-  commissionsAccount,
-  vendorAccount,
-  otherAddress
-]) {
+contract('MoC', function([owner, userAccount, commissionsAccount, vendorAccount, otherAddress]) {
   before(async function() {
     mocHelper = await testHelperBuilder({ owner, useMock: true });
     ({ toContractBN } = mocHelper);

--- a/test/moc/commissions/MoCBProxRedemptionWithCommissions-test.js
+++ b/test/moc/commissions/MoCBProxRedemptionWithCommissions-test.js
@@ -8,7 +8,13 @@ let BUCKET_X2;
 const NOT_ENOUGH_FUNDS_ERROR = "sender doesn't have enough funds to send tx";
 
 // TODO: test BProx redeems with interests
-contract('MoC', function([owner, userAccount, commissionsAccount, vendorAccount, otherAddress]) {
+contract.only('MoC', function([
+  owner,
+  userAccount,
+  commissionsAccount,
+  vendorAccount,
+  otherAddress
+]) {
   before(async function() {
     mocHelper = await testHelperBuilder({ owner, useMock: true });
     ({ toContractBN } = mocHelper);
@@ -333,12 +339,7 @@ contract('MoC', function([owner, userAccount, commissionsAccount, vendorAccount,
           await mocHelper.approveMoCToken(mocHelper.moc.address, mocAmountToApprove, userAccount);
           const prevUserMoCBalance = await mocHelper.getMoCBalance(userAccount);
           const prevUserBtcBalance = toContractBN(await web3.eth.getBalance(userAccount));
-          const tx = await mocHelper.redeemBProx(
-            userAccount,
-            BUCKET_X2,
-            toContractBN(10 * mocHelper.RESERVE_PRECISION),
-            vendorAccount
-          );
+          const tx = await mocHelper.redeemBProx(userAccount, BUCKET_X2, 10, vendorAccount);
           const userMoCBalance = await mocHelper.getMoCBalance(userAccount);
           const diffMoC = prevUserMoCBalance.sub(userMoCBalance);
           const userBtcBalance = toContractBN(await web3.eth.getBalance(userAccount));
@@ -387,12 +388,7 @@ contract('MoC', function([owner, userAccount, commissionsAccount, vendorAccount,
           const prevUserMoCBalance = await mocHelper.getMoCBalance(otherAddress);
 
           // Redeem
-          await mocHelper.redeemBProx(
-            otherAddress,
-            BUCKET_X2,
-            toContractBN(bproxsToRedeem * mocHelper.RESERVE_PRECISION),
-            vendorAccount
-          );
+          await mocHelper.redeemBProx(otherAddress, BUCKET_X2, bproxsToRedeem, vendorAccount);
 
           const userMoCBalance = await mocHelper.getMoCBalance(otherAddress);
           const diffMoCFees = prevUserMoCBalance.sub(userMoCBalance);
@@ -426,12 +422,7 @@ contract('MoC', function([owner, userAccount, commissionsAccount, vendorAccount,
           try {
             await mocHelper.mintMoCToken(failingAddress, 0, owner);
             await mocHelper.approveMoCToken(mocHelper.moc.address, 0, failingAddress);
-            const tx = await mocHelper.redeemBProx(
-              userAccount,
-              BUCKET_X2,
-              toContractBN(10 * mocHelper.RESERVE_PRECISION),
-              vendorAccount
-            );
+            const tx = await mocHelper.redeemBProx(userAccount, BUCKET_X2, 10, vendorAccount);
             assert(tx === null, 'This should not happen');
           } catch (err) {
             assert(
@@ -482,12 +473,7 @@ contract('MoC', function([owner, userAccount, commissionsAccount, vendorAccount,
           const prevUserMoCBalance = await mocHelper.getMoCBalance(otherAddress);
 
           // Redeem
-          await mocHelper.redeemBProx(
-            otherAddress,
-            BUCKET_X2,
-            toContractBN(bproxsToRedeem * mocHelper.RESERVE_PRECISION),
-            vendorAccount
-          );
+          await mocHelper.redeemBProx(otherAddress, BUCKET_X2, bproxsToRedeem, vendorAccount);
 
           const userMoCBalance = await mocHelper.getMoCBalance(otherAddress);
           const diffMoCFees = prevUserMoCBalance.sub(userMoCBalance);

--- a/test/moc/commissions/MoCBproxMintingWithCommissions-test.js
+++ b/test/moc/commissions/MoCBproxMintingWithCommissions-test.js
@@ -271,7 +271,7 @@ contract('MoC : MoCExchange', function([
             await mocHelper.mocInrate.MINT_BPRO_FEES_RBTC()
           );
           await mocHelper.mintDoc(userAccount, 1000, vendorAccount);
-          const mint = mocHelper.mintBProx(userAccount, vendorAccount, BUCKET_X2, 8, 8);
+          const mint = mocHelper.mintBProx(userAccount, BUCKET_X2, 8, vendorAccount, 8);
           await expectRevert(mint, 'amount is not enough');
         });
       });
@@ -286,7 +286,7 @@ contract('MoC : MoCExchange', function([
             await mocHelper.mocInrate.MINT_BPRO_FEES_RBTC()
           );
           await mocHelper.mintDoc(userAccount, 1000, vendorAccount);
-          const mint = mocHelper.mintBProx(userAccount, vendorAccount, BUCKET_X2, 8, 8);
+          const mint = mocHelper.mintBProx(userAccount, BUCKET_X2, 8, vendorAccount, 8);
           await expectRevert(mint, 'amount is not enough');
         });
       });

--- a/test/moc/commissions/MoCFreeDocsWithCommissions-test.js
+++ b/test/moc/commissions/MoCFreeDocsWithCommissions-test.js
@@ -194,13 +194,11 @@ contract('MoC', function([owner, userAccount, commissionsAccount, vendorAccount,
             prevVendorAccountBtcBalance = toContractBN(await web3.eth.getBalance(vendorAccount));
             prevVendorAccountMoCBalance = await mocHelper.getMoCBalance(vendorAccount);
 
-            const redeemTx = await this.moc.redeemFreeDoc(
-              toContractBN(scenario.params.docsToRedeem * mocHelper.RESERVE_PRECISION),
-              vendorAccount,
-              {
-                from: userAccount
-              }
-            );
+            const redeemTx = await mocHelper.redeemFreeDoc({
+              userAccount,
+              docAmount: scenario.params.docsToRedeem,
+              vendorAccount
+            });
             usedGas = await mocHelper.getTxCost(redeemTx);
           });
           describe(`WHEN ${scenario.params.docsToRedeem} doc are redeeming`, function() {
@@ -537,13 +535,11 @@ contract('MoC', function([owner, userAccount, commissionsAccount, vendorAccount,
           prevCommissionsAccountMoCBalance = await mocHelper.getMoCBalance(commissionsAccount);
           prevVendorAccountMoCBalance = await mocHelper.getMoCBalance(vendorAccount);
 
-          const redeemTx = await this.moc.redeemFreeDoc(
-            toContractBN(docsToRedeem * mocHelper.RESERVE_PRECISION),
-            vendorAccount,
-            {
-              from: userAccount
-            }
-          );
+          const redeemTx = await mocHelper.redeemFreeDoc({
+            userAccount,
+            docAmount: docsToRedeem,
+            vendorAccount
+          });
           usedGas = await mocHelper.getTxCost(redeemTx);
         });
         describe(`WHEN ${docsToRedeem} doc are redeeming`, function() {

--- a/test/mocBucketContainer/MoCBucketContainer-test.js
+++ b/test/mocBucketContainer/MoCBucketContainer-test.js
@@ -6,14 +6,13 @@ const NOT_BUCKET_BASE = 'Bucket should not be a base type bucket';
 const bucketH8 = web3.utils.asciiToHex('H8', 32);
 const bucketC0 = web3.utils.asciiToHex('C0', 32);
 let mocHelper;
-// let toContractBN;
+
 let BUCKET_X2;
 let BUCKET_C0;
 contract('MoCBucketContainer', function([owner, account2, vendorAccount]) {
   const c0Cobj = 3;
   before(async function() {
     mocHelper = await testHelperBuilder({ owner });
-    // ({ toContractBN } = mocHelper);
     this.mocState = mocHelper.mocState;
     this.moc = mocHelper.moc;
     this.bprox = mocHelper.bprox;

--- a/test/mocBucketContainer/MoCBucketContainer-test.js
+++ b/test/mocBucketContainer/MoCBucketContainer-test.js
@@ -50,7 +50,7 @@ contract('MoCBucketContainer', function([owner, account2, vendorAccount]) {
       });
       it('THEN mintBProx must revert', async function() {
         await expectRevert(
-          mocHelper.mintBProx(account2, vendorAccount, bucketC0, 1),
+          mocHelper.mintBProx(account2, bucketC0, 1, vendorAccount),
           NOT_BUCKET_BASE
         );
       });
@@ -71,7 +71,7 @@ contract('MoCBucketContainer', function([owner, account2, vendorAccount]) {
     describe('AND the bucket H8 does not exists', function() {
       it('THEN mintBProx must revert', async function() {
         await expectRevert(
-          mocHelper.mintBProx(account2, vendorAccount, bucketH8, 1),
+          mocHelper.mintBProx(account2, bucketH8, 1, vendorAccount),
           BUCKET_NOT_AVAILABLE
         );
       });

--- a/test/mocBucketContainer/MoCBucketContainer-test.js
+++ b/test/mocBucketContainer/MoCBucketContainer-test.js
@@ -6,14 +6,14 @@ const NOT_BUCKET_BASE = 'Bucket should not be a base type bucket';
 const bucketH8 = web3.utils.asciiToHex('H8', 32);
 const bucketC0 = web3.utils.asciiToHex('C0', 32);
 let mocHelper;
-let toContractBN;
+// let toContractBN;
 let BUCKET_X2;
 let BUCKET_C0;
 contract('MoCBucketContainer', function([owner, account2, vendorAccount]) {
   const c0Cobj = 3;
   before(async function() {
     mocHelper = await testHelperBuilder({ owner });
-    ({ toContractBN } = mocHelper);
+    // ({ toContractBN } = mocHelper);
     this.mocState = mocHelper.mocState;
     this.moc = mocHelper.moc;
     this.bprox = mocHelper.bprox;
@@ -56,12 +56,7 @@ contract('MoCBucketContainer', function([owner, account2, vendorAccount]) {
       });
       it('THEN redeemBProx must revert', async function() {
         await expectRevert(
-          mocHelper.redeemBProx(
-            account2,
-            bucketC0,
-            toContractBN(0.5 * mocHelper.RESERVE_PRECISION),
-            vendorAccount
-          ),
+          mocHelper.redeemBProx(account2, bucketC0, 0.5, vendorAccount),
           NOT_BUCKET_BASE
         );
       });
@@ -78,12 +73,7 @@ contract('MoCBucketContainer', function([owner, account2, vendorAccount]) {
       });
       it('THEN redeemBProx must revert', async function() {
         await expectRevert(
-          mocHelper.redeemBProx(
-            account2,
-            bucketH8,
-            toContractBN(0.5 * mocHelper.RESERVE_PRECISION),
-            vendorAccount
-          ),
+          mocHelper.redeemBProx(account2, bucketH8, 0.5, vendorAccount),
           BUCKET_NOT_AVAILABLE
         );
       });

--- a/test/mocBucketContainer/MoCBucketContainer-test.js
+++ b/test/mocBucketContainer/MoCBucketContainer-test.js
@@ -56,7 +56,8 @@ contract('MoCBucketContainer', function([owner, account2, vendorAccount]) {
       });
       it('THEN redeemBProx must revert', async function() {
         await expectRevert(
-          this.moc.redeemBProx(
+          mocHelper.redeemBProx(
+            account2,
             bucketC0,
             toContractBN(0.5 * mocHelper.RESERVE_PRECISION),
             vendorAccount
@@ -77,7 +78,8 @@ contract('MoCBucketContainer', function([owner, account2, vendorAccount]) {
       });
       it('THEN redeemBProx must revert', async function() {
         await expectRevert(
-          this.moc.redeemBProx(
+          mocHelper.redeemBProx(
+            account2,
             bucketH8,
             toContractBN(0.5 * mocHelper.RESERVE_PRECISION),
             vendorAccount

--- a/test/partialExecution/GasLimitDeleveraging-test.js
+++ b/test/partialExecution/GasLimitDeleveraging-test.js
@@ -9,7 +9,7 @@ const initializeDeleveraging = async (owner, vendorAccount, accounts) => {
   await mocHelper.mintBProAmount(owner, 10 * accounts.length, vendorAccount);
   await mocHelper.mintDocAmount(owner, 50000 * accounts.length, vendorAccount);
   await Promise.all(
-    accounts.map(account => mocHelper.mintBProx(account, vendorAccount, BUCKET_X2, 5))
+    accounts.map(account => mocHelper.mintBProx(account, BUCKET_X2, 5, vendorAccount))
   );
 };
 

--- a/test/partialExecution/GasLimitSettlement-test.js
+++ b/test/partialExecution/GasLimitSettlement-test.js
@@ -17,7 +17,7 @@ const initializeSettlement = async (owner, vendorAccount, btcxOwners) => {
 
   await Promise.all(
     promises.concat(
-      btcxOwners.map(acc => mocHelper.mintBProx(acc, vendorAccount, BUCKET_X2, 0.001))
+      btcxOwners.map(acc => mocHelper.mintBProx(acc, BUCKET_X2, 0.001, vendorAccount))
     )
   );
   // Enabling Settlement

--- a/test/partialExecution/PartialSettlement-test.js
+++ b/test/partialExecution/PartialSettlement-test.js
@@ -88,7 +88,7 @@ const runScenario = scenario => {
   return reduced.then(lastTx => txs.concat(lastTx));
 };
 
-contract('MoC: Partial Settlement execution', function([owner, vendorAccount, ...accounts]) {
+contract.only('MoC: Partial Settlement execution', function([owner, vendorAccount, ...accounts]) {
   before(async function() {
     mocHelper = await testHelperBuilder({ owner, useMock: true });
     ({ toContractBN } = mocHelper);

--- a/test/partialExecution/SettlementStopMoc-test.js
+++ b/test/partialExecution/SettlementStopMoc-test.js
@@ -8,8 +8,8 @@ const ACCOUNTS_QUANTITY = 10;
 
 const testFunctionPromises = vendorAccount => {
   const testFunctions = [
-    { name: 'mintBProx', args: [BUCKET_X2, 0, vendorAccount] },
-    { name: 'redeemBProx', args: [BUCKET_X2, 0, vendorAccount] },
+    { name: 'mintBProxVendors', args: [BUCKET_X2, 0, vendorAccount] },
+    { name: 'redeemBProxVendors', args: [BUCKET_X2, 0, vendorAccount] },
     { name: 'redeemDocRequest', args: [0] },
     { name: 'alterRedeemRequestAmount', args: [true, 1] }
   ];

--- a/test/process/MoCBucketLiquidation-test.js
+++ b/test/process/MoCBucketLiquidation-test.js
@@ -81,7 +81,7 @@ contract('MoC: Bucket Liquidation', function([owner, userAccount, otherAccount, 
         const btcToMint = 2;
         // Intentionally uses this method instead of mintBProxAmount,
         // as X2 Price is zero at this state
-        tx = await mocHelper.mintBProx(otherAccount, vendorAccount, BUCKET_X2, btcToMint);
+        tx = await mocHelper.mintBProx(otherAccount, BUCKET_X2, btcToMint, vendorAccount);
       });
       it('AND BucketLiquidation event is emitted', async function() {
         const bucketLiqEvents = mocHelper.findEvents(tx, 'BucketLiquidation');

--- a/test/process/MoCBucketLiquidation-test.js
+++ b/test/process/MoCBucketLiquidation-test.js
@@ -65,7 +65,7 @@ contract('MoC: Bucket Liquidation', function([owner, userAccount, otherAccount, 
     });
     describe('WHEN user tries to redeem his X2 position', function() {
       beforeEach(async function() {
-        tx = await this.moc.redeemBProx(BUCKET_X2, 1, vendorAccount, { from: userAccount });
+        tx = await mocHelper.redeemBProx(userAccount, BUCKET_X2, 1, vendorAccount);
       });
       it('AND BucketLiquidation event should be emitted', async function() {
         const bucketLiqEvents = mocHelper.findEvents(tx, 'BucketLiquidation');

--- a/test/process/MoCDeleveraging-test.js
+++ b/test/process/MoCDeleveraging-test.js
@@ -312,7 +312,7 @@ contract('MoC: Delever X', function([owner, vendorAccount, ...allAccounts]) {
             await mocHelper.mintDocAmount(account, user.nDoc, vendorAccount);
 
             if (user.bproxMint.nB) {
-              await mocHelper.mintBProx(account, vendorAccount, BUCKET_X2, user.bproxMint.nB);
+              await mocHelper.mintBProx(account, BUCKET_X2, user.bproxMint.nB, vendorAccount);
             }
             userPrevBalances[index] = {
               nBProx: await mocHelper.getBProxBalance(BUCKET_X2, accounts[index + 1]),

--- a/test/process/MoCLiquidation-test.js
+++ b/test/process/MoCLiquidation-test.js
@@ -62,11 +62,11 @@ contract('MoC: Liquidation', function([
       mocHelper.assertBig(state, 3, 'State should be AboveCobj');
     });
     [
-      { name: 'mintDoc', args: [1, vendorAccount], value: 1, event: 'StableTokenMint' },
-      { name: 'mintBPro', args: [1, vendorAccount], value: 1, event: 'RiskProMint' },
-      { name: 'redeemBPro', args: [1, vendorAccount], event: 'RiskProxRedeem' },
-      { name: 'mintBProx', args: [BUCKET_X2, 0, vendorAccount], event: 'RiskProxMint' },
-      { name: 'redeemBProx', args: [BUCKET_X2, 1, vendorAccount], event: 'RiskProxRedeem' },
+      { name: 'mintDocVendors', args: [1, vendorAccount], value: 1, event: 'StableTokenMint' },
+      { name: 'mintBProVendors', args: [1, vendorAccount], value: 1, event: 'RiskProMint' },
+      { name: 'redeemBProVendors', args: [1, vendorAccount], event: 'RiskProxRedeem' },
+      { name: 'mintBProxVendors', args: [BUCKET_X2, 0, vendorAccount], event: 'RiskProxMint' },
+      { name: 'redeemBProxVendors', args: [BUCKET_X2, 1, vendorAccount], event: 'RiskProxRedeem' },
       { name: 'evalLiquidation', args: [] },
       { name: 'runSettlement', args: [100] }
     ].forEach(fn => {

--- a/test/process/MoCProtection-test.js
+++ b/test/process/MoCProtection-test.js
@@ -38,8 +38,8 @@ contract('MoC: Protection mode', function([owner, userAccount, otherAccount, ven
       mocHelper.assertBig(state, 3, 'State should be AboveCobj');
     });
     [
-      { name: 'mintBPro', args: [1, vendorAccount], value: 1, event: 'RiskProMint' },
-      { name: 'redeemFreeDoc', args: [1, vendorAccount], event: 'FreeStableTokenRedeem' }
+      { name: 'mintBProVendors', args: [1, vendorAccount], value: 1, event: 'RiskProMint' },
+      { name: 'redeemFreeDocVendors', args: [1, vendorAccount], event: 'FreeStableTokenRedeem' }
     ].forEach(fn => {
       describe(`WHEN someone executes ${fn.name}`, function() {
         let tx;

--- a/test/testHelpers/functionHelper.js
+++ b/test/testHelpers/functionHelper.js
@@ -151,11 +151,12 @@ const mintBProx = moc => async (from, bucket, btcToMint, vendorAccount = zeroAdd
 
 const redeemBProx = moc => async (from, bucket, amount, vendorAccount = zeroAddress) => {
   const reservePrecision = await moc.getReservePrecision();
+  const amountWithPrecision = new BN(amount).mul(reservePrecision);
   return vendorAccount !== zeroAddress
-    ? moc.redeemBProxVendors(bucket, toContract(amount * reservePrecision), vendorAccount, {
+    ? moc.redeemBProxVendors(bucket, toContract(amountWithPrecision), vendorAccount, {
         from
       })
-    : moc.redeemBProx(bucket, toContract(amount * reservePrecision), { from });
+    : moc.redeemBProx(bucket, toContract(amountWithPrecision), { from });
 };
 
 const rbtcNeededToMintBpro = (moc, mocState) => async bproAmount => {

--- a/test/testHelpers/functionHelper.js
+++ b/test/testHelpers/functionHelper.js
@@ -203,7 +203,7 @@ const mintBProAmount = (moc, mocState, mocInrate, mocVendors) => async (
     new BigNumber(btcTotal).plus(commissionRbtcAmount).plus(markupRbtcAmount)
   );
 
-  return moc.mintBPro(toContract(btcTotal), vendorAccount, { from: account, value });
+  return moc.mintBProVendors(toContract(btcTotal), vendorAccount, { from: account, value });
 };
 
 const mintDocAmount = (moc, btcPriceProvider, mocInrate, mocVendors) => async (
@@ -244,7 +244,7 @@ const mintDocAmount = (moc, btcPriceProvider, mocInrate, mocVendors) => async (
 
   const value = toContract(btcTotal.plus(commissionRbtcAmount).plus(markupRbtcAmount));
 
-  return moc.mintDoc(toContract(btcTotal), vendorAccount, { from: account, value });
+  return moc.mintDocVendors(toContract(btcTotal), vendorAccount, { from: account, value });
 };
 
 const mintBProxAmount = (moc, mocState, mocInrate, mocVendors) => async (
@@ -283,7 +283,7 @@ const mintBProxAmount = (moc, mocState, mocInrate, mocVendors) => async (
     .add(btcTotal)
     .add(btcTotal);
 
-  return moc.mintBProx(bucket, btcTotal, vendorAccount, { from: account, value });
+  return moc.mintBProxVendors(bucket, btcTotal, vendorAccount, { from: account, value });
 };
 
 const redeemBPro = moc => async (from, amount, vendorAccount = zeroAddress) => {


### PR DESCRIPTION
- Renamed functions with `vendorAccount` parameter to `mintXVendors` and `redeemXVendors`
- Added functions `mintX` and `redeemX` for retrocompatibility. These functions call the respective functions named in previous item, and pass `address(0)` as `vendorAccount` parameter
- Added test for retrocompatible functions
- Modified existing tests and test helpers in order to adapt them for new functions and retrocompatibility