### PR TITLE
feat: add gas price limit

### DIFF
--- a/contracts/changers/MaxGasPriceChanger.sol
+++ b/contracts/changers/MaxGasPriceChanger.sol
@@ -1,0 +1,109 @@
+pragma solidity ^0.5.8;
+
+import "zos-lib/contracts/upgradeability/AdminUpgradeabilityProxy.sol";
+import "moc-governance/contracts/Governance/ChangeContract.sol";
+import "moc-governance/contracts/Upgradeability/UpgradeDelegator.sol";
+import "../MoC.sol";
+
+/**
+  @title MaxGasPriceChanger
+  @notice This contract is an upgradeChanger to add a gas price limit on
+  mint and redeem operation for MoC and RoC protocols
+ */
+contract MaxGasPriceChanger is ChangeContract {
+
+  UpgradeDelegator public upgradeDelegator;
+  AdminUpgradeabilityProxy public MOC_proxy;
+  address public MOC_newImplementation;
+
+  AdminUpgradeabilityProxy public ROC_proxy;
+  address public ROC_newImplementation;
+
+  AdminUpgradeabilityProxy public stopper_proxy;
+  address public stopper_newImplementation;
+
+  uint256 public maxGasPrice;
+
+  /**
+    @notice Constructor
+    @param _upgradeDelegator Address of the upgradeDelegator in charge of that proxy
+    @param _MOC_proxy Address of the MOC proxy to be upgraded
+    @param _MOC_newImplementation Address of the contract the MOC proxy will delegate to
+    @param _ROC_proxy Address of the ROC proxy to be upgraded
+    @param _ROC_newImplementation Address of the contract the ROC proxy will delegate to
+    @param _stopper_newImplementation Address of the contract the Stopper proxy will delegate to
+    @param _maxGasPrice gas price limit to mint and redeem operations
+  */
+  constructor(
+    UpgradeDelegator _upgradeDelegator,
+    AdminUpgradeabilityProxy _MOC_proxy,
+    address _MOC_newImplementation,
+    AdminUpgradeabilityProxy _ROC_proxy,
+    address _ROC_newImplementation,
+    address _stopper_newImplementation,
+    uint256 _maxGasPrice
+    ) public {
+    upgradeDelegator = _upgradeDelegator;
+    MOC_proxy = _MOC_proxy;
+    MOC_newImplementation = _MOC_newImplementation;
+    ROC_proxy = _ROC_proxy;
+    ROC_newImplementation = _ROC_newImplementation;
+    maxGasPrice = _maxGasPrice;
+    address mocStopper = MoC(address(_MOC_proxy)).stopper();
+    address rocStopper = MoC(address(_ROC_proxy)).stopper();
+    require(mocStopper == rocStopper, "MoC and RoC have different stopper address set");
+    stopper_proxy = castToAdminUpgradeabilityProxy(address(mocStopper));
+    stopper_newImplementation = _stopper_newImplementation;
+  }
+
+  /**
+   * @notice cast non payable address to AdminUpgradebilityProxy
+   * @param _address address to cast
+   */
+  function castToAdminUpgradeabilityProxy(address _address) internal returns (AdminUpgradeabilityProxy proxy) {
+    return AdminUpgradeabilityProxy(address(uint160(_address)));
+  }
+
+  /**
+    @notice Execute the changes.
+    @dev Should be called by the governor, but this contract does not check that explicitly because it is not its responsability in
+    the current architecture
+    IMPORTANT: This function should not be overriden, you should only redefine the _beforeUpgrade and _afterUpgrade to use this template
+   */
+  function execute() external {
+    _beforeUpgrade();
+    _upgrade();
+    _afterUpgrade();
+  }
+
+  /**
+    @notice Upgrade the proxy to the newImplementation
+    @dev IMPORTANT: This function should not be overriden
+   */
+  function _upgrade() internal {
+    // upgrade MoC
+    upgradeDelegator.upgrade(MOC_proxy, MOC_newImplementation);
+    // upgrade RoC
+    upgradeDelegator.upgrade(ROC_proxy, ROC_newImplementation);
+    // upgrade Stopper
+    upgradeDelegator.upgrade(stopper_proxy, stopper_newImplementation);
+  }
+
+  /**
+    @notice Intended to prepare the system for the upgrade
+    @dev This function can be overriden by child changers to upgrade contracts that require some preparation before the upgrade
+   */
+  function _beforeUpgrade() internal {
+  }
+
+  /**
+    @notice Intended to do the final tweaks after the upgrade, for example initialize the contract
+    @dev This function can be overriden by child changers to upgrade contracts that require some changes after the upgrade
+   */
+  function _afterUpgrade() internal {
+    // set max gas price to MoC
+    MoC(address(MOC_proxy)).setMaxGasPrice(maxGasPrice);
+    // set max gas price to RoC
+    MoC(address(ROC_proxy)).setMaxGasPrice(maxGasPrice);
+  }
+}

--- a/contracts/changers/UpgraderChanger.sol
+++ b/contracts/changers/UpgraderChanger.sol
@@ -4,6 +4,9 @@ import "zos-lib/contracts/upgradeability/AdminUpgradeabilityProxy.sol";
 import "moc-governance/contracts/Governance/ChangeContract.sol";
 import "moc-governance/contracts/Upgradeability/UpgradeDelegator.sol";
 
+// import to compile MoC_v0115 for testing
+import "../../contracts_updated/MoC_v0115.sol";
+
 /**
   @title UpgraderChanger
   @notice This contract is a ChangeContract intended to be used when

--- a/contracts/governance/StopperV2.sol
+++ b/contracts/governance/StopperV2.sol
@@ -1,0 +1,53 @@
+pragma solidity ^0.5.8;
+
+import "openzeppelin-eth/contracts/ownership/Ownable.sol";
+import "moc-governance/contracts/Stopper/Stoppable.sol";
+
+/**
+  @title Stopper
+  @notice The contract in charge of handling the stoppability and maximum gas Price limit 
+    of the contract that define this contract as its stopper.
+  @dev both pausing or setting a really low maxGasPrice has the same effect on the protocol,
+    is prevents anyone from using it. And it also requires the same level of reactivity, 
+    as a sudden network gasPrice spike, would require immediate maxGasPrice adjustment to compensate, 
+    as it would a pause. Stopper, holds owner account responsible for both this two features.
+ */
+contract StopperV2 is Ownable {
+
+  /**
+    @notice Pause activeContract if it is stoppable
+    @param activeContract Contract to be paused
+   */
+  function pause(Stoppable activeContract) external onlyOwner {
+    activeContract.pause();
+  }
+
+  /**
+    @notice Unpause pausedContract if it is stoppable
+    @param pausedContract Contract to be unpaused
+   */
+  function unpause(Stoppable pausedContract) external onlyOwner {
+    pausedContract.unpause();
+  }
+
+  /**
+    @notice set new gas price limit to target contract
+    @param gasPriceLimitedContract Contract to be updated with new gas price limit
+    @param maxGasPrice_ new gas price limit
+   */
+  function setMaxGasPrice(GasPriceLimited gasPriceLimitedContract, uint256 maxGasPrice_) external onlyOwner {
+    gasPriceLimitedContract.setMaxGasPrice(maxGasPrice_);
+  }
+
+  // Leave a gap betweeen inherited contracts variables in order to be
+  // able to add more variables in them later
+  uint256[50] private upgradeGap;
+}
+
+interface GasPriceLimited {
+    /**
+   * @notice set new gas price limit
+   * @param maxGasPrice_ new gas price limit
+   */
+  function setMaxGasPrice(uint256 maxGasPrice_) external;
+}

--- a/contracts_updated/MoC_v0115.sol
+++ b/contracts_updated/MoC_v0115.sol
@@ -2,25 +2,25 @@ pragma solidity ^0.5.8;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/lifecycle/Pausable.sol";
-import "./MoCBProxManager.sol";
-import "./interface/IMoCState.sol";
-import "./MoCLibConnection.sol";
-import "./interface/IMoCSettlement.sol";
-import "./interface/IMoCExchange.sol";
-import "./base/MoCBase.sol";
+import "../contracts/MoCBProxManager.sol";
+import "../contracts/interface/IMoCState.sol";
+import "../contracts/MoCLibConnection.sol";
+import "../contracts/interface/IMoCSettlement.sol";
+import "../contracts/interface/IMoCExchange.sol";
+import "../contracts/base/MoCBase.sol";
 import "moc-governance/contracts/Stopper/Stoppable.sol";
 import "moc-governance/contracts/Governance/IGovernor.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
-import "./interface/IMoCVendors.sol";
-import "./interface/IMoCInrate.sol";
-import "./interface/IMoC.sol";
+import "../contracts/interface/IMoCVendors.sol";
+import "../contracts/interface/IMoCInrate.sol";
+import "../contracts/interface/IMoC.sol";
 
-contract MoCEvents {
+contract MoCEvents_v0115 {
   event BucketLiquidation(bytes32 bucket);
   event ContractLiquidated(address mocAddress);
 }
 
-contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable, IMoC {
+contract MoC_v0115 is MoCEvents_v0115, MoCLibConnection, MoCBase, Stoppable, IMoC {
   using SafeMath for uint256;
 
   /// @dev Contracts.
@@ -57,14 +57,12 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable, IMoC {
     @param governorAddress Governor contract address
     @param stopperAddress Stopper contract address
     @param startStoppable Indicates if the contract starts being unstoppable or not
-    @param maxGasPrice_ gas price limit to mint and redeem operations
   */
   function initialize(
     address connectorAddress,
     address governorAddress,
     address stopperAddress,
-    bool startStoppable,
-    uint256 maxGasPrice_
+    bool startStoppable
   ) public initializer {
     initializePrecisions();
     initializeBase(connectorAddress);
@@ -78,7 +76,6 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable, IMoC {
     mocInrate = IMoCInrate(connector.mocInrate());
     //initializeGovernanceContracts
     Stoppable.initialize(stopperAddress, IGovernor(governorAddress), startStoppable);
-    maxGasPrice = maxGasPrice_;
   }
 
   /****************************INTERFACE*******************************************/
@@ -154,7 +151,7 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable, IMoC {
    */
   function mintBProVendors(uint256 btcToMint, address payable vendorAccount)
   public payable
-  whenNotPaused() transitionState() notInProtectionMode() isValidGasPrice() {
+  whenNotPaused() transitionState() notInProtectionMode() {
     /** UPDATE V0112: 24/09/2020 - Upgrade to support multiple commission rates **/
     (uint256 totalBtcSpent,
     uint256 btcCommission,
@@ -191,7 +188,7 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable, IMoC {
   */
   function redeemBProVendors(uint256 bproAmount, address payable vendorAccount)
   public
-  whenNotPaused() transitionState() atLeastState(IMoCState.States.AboveCobj) isValidGasPrice() {
+  whenNotPaused() transitionState() atLeastState(IMoCState.States.AboveCobj) {
     /** UPDATE V0112: 24/09/2020 - Upgrade to support multiple commission rates **/
     (uint256 btcAmount,
     uint256 btcCommission,
@@ -228,7 +225,7 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable, IMoC {
    */
   function mintDocVendors(uint256 btcToMint, address payable vendorAccount)
   public payable
-  whenNotPaused() transitionState() atLeastState(IMoCState.States.AboveCobj) isValidGasPrice() {
+  whenNotPaused() transitionState() atLeastState(IMoCState.States.AboveCobj) {
     /** UPDATE V0112: 24/09/2020 - Upgrade to support multiple commission rates **/
     (uint256 totalBtcSpent,
     uint256 btcCommission,
@@ -327,7 +324,7 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable, IMoC {
   */
   function redeemFreeDocVendors(uint256 docAmount, address payable vendorAccount)
   public
-  whenNotPaused() transitionState() notInProtectionMode() isValidGasPrice() {
+  whenNotPaused() transitionState() notInProtectionMode() {
     /** UPDATE V0112: 24/09/2020 - Upgrade to support multiple commission rates **/
     (uint256 btcAmount,
     uint256 btcCommission,
@@ -699,28 +696,7 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable, IMoC {
       _;
   }
 
-  /**
-   * @notice validate that the given gas price is less or equal to the gas price limit
-   */
-  modifier isValidGasPrice() {
-    require(tx.gasprice <= maxGasPrice, "gas price is above the max allowed");
-    _;
-  }
-
-  /**
-   * @notice allows the pauser or an authorized changer to update the gas price limit
-   *  The pauser is a multisig that could be used in this case to speed up the max gas price
-   *  change if it is necessary
-   * @param maxGasPrice_ new gas price limit
-   */
-  function setMaxGasPrice(uint256 maxGasPrice_) external {
-    require(stopper == msg.sender || governor.isAuthorizedChanger(msg.sender), "not authorized changer or stopper");
-    maxGasPrice = maxGasPrice_;
-  }
-
-  uint256 public maxGasPrice;
-
   // Leave a gap betweeen inherited contracts variables in order to be
   // able to add more variables in them later
-  uint256[49] private upgradeGap;
+  uint256[50] private upgradeGap;
 }

--- a/migrations/configs/config.json
+++ b/migrations/configs/config.json
@@ -1,5 +1,6 @@
 {
   "coverage": {
+    "maxGasPrice": 21000000000,
     "initialPrice": 10000,
     "initialEma": 10000,
     "dayBlockSpan": 20,
@@ -45,6 +46,7 @@
     }
   },
   "development": {
+    "maxGasPrice": 21000000000,
     "initialPrice": 7800,
     "initialEma": 7800,
     "dayBlockSpan": 20,
@@ -90,6 +92,7 @@
     }
   },
   "regtest": {
+    "maxGasPrice": 65820000,
     "initialPrice": 7800,
     "initialEma": 7800,
     "dayBlockSpan": 20,
@@ -135,6 +138,7 @@
     }
   },
   "rskTestnet": {
+    "maxGasPrice": 65820000,
     "oracle": "0x667bd3d048FaEBb85bAa0E9f9D87cF4c8CDFE849",
     "governor": "0x9258531274B945eB628656F4b30e8216938A619C",
     "stopper": "0x0BE712DD242BF133417f6e389436783Fccb62e9e",
@@ -185,6 +189,7 @@
     }
   },
   "rskMainnet": {
+    "maxGasPrice": 65820000,
     "oracle": "0x667bd3d048FaEBb85bAa0E9f9D87cF4c8CDFE849",
     "governor": "0x9258531274B945eB628656F4b30e8216938A619C",
     "stopper": "0x0BE712DD242BF133417f6e389436783Fccb62e9e",

--- a/migrations/utils.js
+++ b/migrations/utils.js
@@ -413,7 +413,8 @@ const makeUtils = async (artifacts, networkName, config, owner, deployer) => {
       mocConnector.address,
       governorAddress,
       stopperAddress,
-      config.startStoppable
+      config.startStoppable,
+      config.maxGasPrice
     );
     console.log('MoC Initialized');
 

--- a/scripts/contract_flatten/MaxGasPriceChanger_flat.sol
+++ b/scripts/contract_flatten/MaxGasPriceChanger_flat.sol
@@ -23,6 +23,698 @@ If you have any questions, comments or interest in pursuing any other use cases,
 pragma solidity ^0.5.8;
 
 
+
+
+
+
+/**
+ * @title Proxy
+ * @dev Implements delegation of calls to other contracts, with proper
+ * forwarding of return values and bubbling of failures.
+ * It defines a fallback function that delegates all calls to the address
+ * returned by the abstract _implementation() internal function.
+ */
+contract Proxy {
+  /**
+   * @dev Fallback function.
+   * Implemented entirely in `_fallback`.
+   */
+  function () payable external {
+    _fallback();
+  }
+
+  /**
+   * @return The Address of the implementation.
+   */
+  function _implementation() internal view returns (address);
+
+  /**
+   * @dev Delegates execution to an implementation contract.
+   * This is a low level function that doesn't return to its internal call site.
+   * It will return to the external caller whatever the implementation returns.
+   * @param implementation Address to delegate.
+   */
+  function _delegate(address implementation) internal {
+    assembly {
+      // Copy msg.data. We take full control of memory in this inline assembly
+      // block because it will not return to Solidity code. We overwrite the
+      // Solidity scratch pad at memory position 0.
+      calldatacopy(0, 0, calldatasize)
+
+      // Call the implementation.
+      // out and outsize are 0 because we don't know the size yet.
+      let result := delegatecall(gas, implementation, 0, calldatasize, 0, 0)
+
+      // Copy the returned data.
+      returndatacopy(0, 0, returndatasize)
+
+      switch result
+      // delegatecall returns 0 on error.
+      case 0 { revert(0, returndatasize) }
+      default { return(0, returndatasize) }
+    }
+  }
+
+  /**
+   * @dev Function that is run as the first thing in the fallback function.
+   * Can be redefined in derived contracts to add functionality.
+   * Redefinitions must call super._willFallback().
+   */
+  function _willFallback() internal {
+  }
+
+  /**
+   * @dev fallback implementation.
+   * Extracted to enable manual triggering.
+   */
+  function _fallback() internal {
+    _willFallback();
+    _delegate(_implementation());
+  }
+}
+
+
+/**
+ * Utility library of inline functions on addresses
+ *
+ * Source https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-solidity/v2.1.3/contracts/utils/Address.sol
+ * This contract is copied here and renamed from the original to avoid clashes in the compiled artifacts
+ * when the user imports a zos-lib contract (that transitively causes this contract to be compiled and added to the
+ * build/artifacts folder) as well as the vanilla Address implementation from an openzeppelin version.
+ */
+library ZOSLibAddress {
+    /**
+     * Returns whether the target address is a contract
+     * @dev This function will return false if invoked during the constructor of a contract,
+     * as the code is not actually created until after the constructor finishes.
+     * @param account address of the account to check
+     * @return whether the target address is a contract
+     */
+    function isContract(address account) internal view returns (bool) {
+        uint256 size;
+        // XXX Currently there is no better way to check if there is a contract in an address
+        // than to check the size of the code at that address.
+        // See https://ethereum.stackexchange.com/a/14016/36603
+        // for more details about how this works.
+        // TODO Check this again before the Serenity release, because all addresses will be
+        // contracts then.
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+}
+
+/**
+ * @title BaseUpgradeabilityProxy
+ * @dev This contract implements a proxy that allows to change the
+ * implementation address to which it will delegate.
+ * Such a change is called an implementation upgrade.
+ */
+contract BaseUpgradeabilityProxy is Proxy {
+  /**
+   * @dev Emitted when the implementation is upgraded.
+   * @param implementation Address of the new implementation.
+   */
+  event Upgraded(address indexed implementation);
+
+  /**
+   * @dev Storage slot with the address of the current implementation.
+   * This is the keccak-256 hash of "org.zeppelinos.proxy.implementation", and is
+   * validated in the constructor.
+   */
+  bytes32 internal constant IMPLEMENTATION_SLOT = 0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3;
+
+  /**
+   * @dev Returns the current implementation.
+   * @return Address of the current implementation
+   */
+  function _implementation() internal view returns (address impl) {
+    bytes32 slot = IMPLEMENTATION_SLOT;
+    assembly {
+      impl := sload(slot)
+    }
+  }
+
+  /**
+   * @dev Upgrades the proxy to a new implementation.
+   * @param newImplementation Address of the new implementation.
+   */
+  function _upgradeTo(address newImplementation) internal {
+    _setImplementation(newImplementation);
+    emit Upgraded(newImplementation);
+  }
+
+  /**
+   * @dev Sets the implementation address of the proxy.
+   * @param newImplementation Address of the new implementation.
+   */
+  function _setImplementation(address newImplementation) internal {
+    require(ZOSLibAddress.isContract(newImplementation), "Cannot set a proxy implementation to a non-contract address");
+
+    bytes32 slot = IMPLEMENTATION_SLOT;
+
+    assembly {
+      sstore(slot, newImplementation)
+    }
+  }
+}
+
+
+/**
+ * @title UpgradeabilityProxy
+ * @dev Extends BaseUpgradeabilityProxy with a constructor for initializing
+ * implementation and init data.
+ */
+contract UpgradeabilityProxy is BaseUpgradeabilityProxy {
+  /**
+   * @dev Contract constructor.
+   * @param _logic Address of the initial implementation.
+   * @param _data Data to send as msg.data to the implementation to initialize the proxied contract.
+   * It should include the signature and the parameters of the function to be called, as described in
+   * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
+   * This parameter is optional, if no data is given the initialization call to proxied contract will be skipped.
+   */
+  constructor(address _logic, bytes memory _data) public payable {
+    assert(IMPLEMENTATION_SLOT == keccak256("org.zeppelinos.proxy.implementation"));
+    _setImplementation(_logic);
+    if(_data.length > 0) {
+      (bool success,) = _logic.delegatecall(_data);
+      require(success);
+    }
+  }  
+}
+
+
+/**
+ * @title BaseAdminUpgradeabilityProxy
+ * @dev This contract combines an upgradeability proxy with an authorization
+ * mechanism for administrative tasks.
+ * All external functions in this contract must be guarded by the
+ * `ifAdmin` modifier. See ethereum/solidity#3864 for a Solidity
+ * feature proposal that would enable this to be done automatically.
+ */
+contract BaseAdminUpgradeabilityProxy is BaseUpgradeabilityProxy {
+  /**
+   * @dev Emitted when the administration has been transferred.
+   * @param previousAdmin Address of the previous admin.
+   * @param newAdmin Address of the new admin.
+   */
+  event AdminChanged(address previousAdmin, address newAdmin);
+
+  /**
+   * @dev Storage slot with the admin of the contract.
+   * This is the keccak-256 hash of "org.zeppelinos.proxy.admin", and is
+   * validated in the constructor.
+   */
+  bytes32 internal constant ADMIN_SLOT = 0x10d6a54a4754c8869d6886b5f5d7fbfa5b4522237ea5c60d11bc4e7a1ff9390b;
+
+  /**
+   * @dev Modifier to check whether the `msg.sender` is the admin.
+   * If it is, it will run the function. Otherwise, it will delegate the call
+   * to the implementation.
+   */
+  modifier ifAdmin() {
+    if (msg.sender == _admin()) {
+      _;
+    } else {
+      _fallback();
+    }
+  }
+
+  /**
+   * @return The address of the proxy admin.
+   */
+  function admin() external ifAdmin returns (address) {
+    return _admin();
+  }
+
+  /**
+   * @return The address of the implementation.
+   */
+  function implementation() external ifAdmin returns (address) {
+    return _implementation();
+  }
+
+  /**
+   * @dev Changes the admin of the proxy.
+   * Only the current admin can call this function.
+   * @param newAdmin Address to transfer proxy administration to.
+   */
+  function changeAdmin(address newAdmin) external ifAdmin {
+    require(newAdmin != address(0), "Cannot change the admin of a proxy to the zero address");
+    emit AdminChanged(_admin(), newAdmin);
+    _setAdmin(newAdmin);
+  }
+
+  /**
+   * @dev Upgrade the backing implementation of the proxy.
+   * Only the admin can call this function.
+   * @param newImplementation Address of the new implementation.
+   */
+  function upgradeTo(address newImplementation) external ifAdmin {
+    _upgradeTo(newImplementation);
+  }
+
+  /**
+   * @dev Upgrade the backing implementation of the proxy and call a function
+   * on the new implementation.
+   * This is useful to initialize the proxied contract.
+   * @param newImplementation Address of the new implementation.
+   * @param data Data to send as msg.data in the low level call.
+   * It should include the signature and the parameters of the function to be called, as described in
+   * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
+   */
+  function upgradeToAndCall(address newImplementation, bytes calldata data) payable external ifAdmin {
+    _upgradeTo(newImplementation);
+    (bool success,) = newImplementation.delegatecall(data);
+    require(success);
+  }
+
+  /**
+   * @return The admin slot.
+   */
+  function _admin() internal view returns (address adm) {
+    bytes32 slot = ADMIN_SLOT;
+    assembly {
+      adm := sload(slot)
+    }
+  }
+
+  /**
+   * @dev Sets the address of the proxy admin.
+   * @param newAdmin Address of the new proxy admin.
+   */
+  function _setAdmin(address newAdmin) internal {
+    bytes32 slot = ADMIN_SLOT;
+
+    assembly {
+      sstore(slot, newAdmin)
+    }
+  }
+
+  /**
+   * @dev Only fall back when the sender is not the admin.
+   */
+  function _willFallback() internal {
+    require(msg.sender != _admin(), "Cannot call fallback function from the proxy admin");
+    super._willFallback();
+  }
+}
+
+
+/**
+ * @title AdminUpgradeabilityProxy
+ * @dev Extends from BaseAdminUpgradeabilityProxy with a constructor for 
+ * initializing the implementation, admin, and init data.
+ */
+contract AdminUpgradeabilityProxy is BaseAdminUpgradeabilityProxy, UpgradeabilityProxy {
+  /**
+   * Contract constructor.
+   * @param _logic address of the initial implementation.
+   * @param _admin Address of the proxy administrator.
+   * @param _data Data to send as msg.data to the implementation to initialize the proxied contract.
+   * It should include the signature and the parameters of the function to be called, as described in
+   * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
+   * This parameter is optional, if no data is given the initialization call to proxied contract will be skipped.
+   */
+  constructor(address _logic, address _admin, bytes memory _data) UpgradeabilityProxy(_logic, _data) public payable {
+    assert(ADMIN_SLOT == keccak256("org.zeppelinos.proxy.admin"));
+    _setAdmin(_admin);
+  }
+}
+
+
+/**
+  @title ChangeContract
+  @notice This interface is the one used by the governance system.
+  @dev If you plan to do some changes to a system governed by this project you should write a contract
+  that does those changes, like a recipe. This contract MUST not have ANY kind of public or external function
+  that modifies the state of this ChangeContract, otherwise you could run into front-running issues when the governance
+  system is fully in place.
+ */
+interface ChangeContract {
+
+  /**
+    @notice Override this function with a recipe of the changes to be done when this ChangeContract
+    is executed
+   */
+  function execute() external;
+}
+
+
+
+
+/**
+ * @title Ownable
+ * @dev The Ownable contract has an owner address, and provides basic authorization control
+ * functions, this simplifies the implementation of "user permissions".
+ *
+ * Source https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-solidity/v2.1.3/contracts/ownership/Ownable.sol
+ * This contract is copied here and renamed from the original to avoid clashes in the compiled artifacts
+ * when the user imports a zos-lib contract (that transitively causes this contract to be compiled and added to the
+ * build/artifacts folder) as well as the vanilla Ownable implementation from an openzeppelin version.
+ */
+contract ZOSLibOwnable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev The Ownable constructor sets the original `owner` of the contract to the sender
+     * account.
+     */
+    constructor () internal {
+        _owner = msg.sender;
+        emit OwnershipTransferred(address(0), _owner);
+    }
+
+    /**
+     * @return the address of the owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(isOwner());
+        _;
+    }
+
+    /**
+     * @return true if `msg.sender` is the owner of the contract.
+     */
+    function isOwner() public view returns (bool) {
+        return msg.sender == _owner;
+    }
+
+    /**
+     * @dev Allows the current owner to relinquish control of the contract.
+     * @notice Renouncing to ownership will leave the contract without an owner.
+     * It will not be possible to call the functions with the `onlyOwner`
+     * modifier anymore.
+     */
+    function renounceOwnership() public onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Allows the current owner to transfer control of the contract to a newOwner.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers control of the contract to a newOwner.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function _transferOwnership(address newOwner) internal {
+        require(newOwner != address(0));
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}
+
+/**
+ * @title ProxyAdmin
+ * @dev This contract is the admin of a proxy, and is in charge
+ * of upgrading it as well as transferring it to another admin.
+ */
+contract ProxyAdmin is ZOSLibOwnable {
+  
+  /**
+   * @dev Returns the current implementation of a proxy.
+   * This is needed because only the proxy admin can query it.
+   * @return The address of the current implementation of the proxy.
+   */
+  function getProxyImplementation(AdminUpgradeabilityProxy proxy) public view returns (address) {
+    // We need to manually run the static call since the getter cannot be flagged as view
+    // bytes4(keccak256("implementation()")) == 0x5c60da1b
+    (bool success, bytes memory returndata) = address(proxy).staticcall(hex"5c60da1b");
+    require(success);
+    return abi.decode(returndata, (address));
+  }
+
+  /**
+   * @dev Returns the admin of a proxy. Only the admin can query it.
+   * @return The address of the current admin of the proxy.
+   */
+  function getProxyAdmin(AdminUpgradeabilityProxy proxy) public view returns (address) {
+    // We need to manually run the static call since the getter cannot be flagged as view
+    // bytes4(keccak256("admin()")) == 0xf851a440
+    (bool success, bytes memory returndata) = address(proxy).staticcall(hex"f851a440");
+    require(success);
+    return abi.decode(returndata, (address));
+  }
+
+  /**
+   * @dev Changes the admin of a proxy.
+   * @param proxy Proxy to change admin.
+   * @param newAdmin Address to transfer proxy administration to.
+   */
+  function changeProxyAdmin(AdminUpgradeabilityProxy proxy, address newAdmin) public onlyOwner {
+    proxy.changeAdmin(newAdmin);
+  }
+
+  /**
+   * @dev Upgrades a proxy to the newest implementation of a contract.
+   * @param proxy Proxy to be upgraded.
+   * @param implementation the address of the Implementation.
+   */
+  function upgrade(AdminUpgradeabilityProxy proxy, address implementation) public onlyOwner {
+    proxy.upgradeTo(implementation);
+  }
+
+  /**
+   * @dev Upgrades a proxy to the newest implementation of a contract and forwards a function call to it.
+   * This is useful to initialize the proxied contract.
+   * @param proxy Proxy to be upgraded.
+   * @param implementation Address of the Implementation.
+   * @param data Data to send as msg.data in the low level call.
+   * It should include the signature and the parameters of the function to be called, as described in
+   * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
+   */
+  function upgradeAndCall(AdminUpgradeabilityProxy proxy, address implementation, bytes memory data) payable public onlyOwner {
+    proxy.upgradeToAndCall.value(msg.value)(implementation, data);
+  }
+}
+
+
+
+
+/**
+  @title Governor
+  @notice Governor interface. This functions should be overwritten to
+  enable the comunnication with the rest of the system
+  */
+interface IGovernor{
+
+  /**
+    @notice Function to be called to make the changes in changeContract
+    @dev This function should be protected somehow to only execute changes that
+    benefit the system. This decision process is independent of this architechture
+    therefore is independent of this interface too
+    @param changeContract Address of the contract that will execute the changes
+   */
+  function executeChange(ChangeContract changeContract) external;
+
+  /**
+    @notice Function to be called to make the changes in changeContract
+    @param _changer Address of the contract that will execute the changes
+   */
+  function isAuthorizedChanger(address _changer) external view returns (bool);
+}
+
+
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable {
+
+  /**
+   * @dev Indicates that the contract has been initialized.
+   */
+  bool private initialized;
+
+  /**
+   * @dev Indicates that the contract is in the process of being initialized.
+   */
+  bool private initializing;
+
+  /**
+   * @dev Modifier to use in the initializer function of a contract.
+   */
+  modifier initializer() {
+    require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+
+    bool isTopLevelCall = !initializing;
+    if (isTopLevelCall) {
+      initializing = true;
+      initialized = true;
+    }
+
+    _;
+
+    if (isTopLevelCall) {
+      initializing = false;
+    }
+  }
+
+  /// @dev Returns true if and only if the function is running in the constructor
+  function isConstructor() private view returns (bool) {
+    // extcodesize checks the size of the code stored in an address, and
+    // address returns the current address. Since the code is still not
+    // deployed when running a constructor, any checks on its code size will
+    // yield zero, making it an effective way to detect if a contract is
+    // under construction or not.
+    uint256 cs;
+    assembly { cs := extcodesize(address) }
+    return cs == 0;
+  }
+
+  // Reserved storage space to allow for layout changes in the future.
+  uint256[50] private ______gap;
+}
+
+
+/**
+  @title Governed
+  @notice Base contract to be inherited by governed contracts
+  @dev This contract is not usable on its own since it does not have any _productive useful_ behaviour
+  The only purpose of this contract is to define some useful modifiers and functions to be used on the
+  governance aspect of the child contract
+  */
+contract Governed is Initializable {
+
+  /**
+    @notice The address of the contract which governs this one
+   */
+  IGovernor public governor;
+
+  string constant private NOT_AUTHORIZED_CHANGER = "not_authorized_changer";
+
+  /**
+    @notice Modifier that protects the function
+    @dev You should use this modifier in any function that should be called through
+    the governance system
+   */
+  modifier onlyAuthorizedChanger() {
+    require(governor.isAuthorizedChanger(msg.sender), NOT_AUTHORIZED_CHANGER);
+    _;
+  }
+
+  /**
+    @notice Initialize the contract with the basic settings
+    @dev This initialize replaces the constructor but it is not called automatically.
+    It is necessary because of the upgradeability of the contracts
+    @param _governor Governor address
+   */
+  function initialize(IGovernor _governor) public initializer {
+    governor = _governor;
+  }
+
+  /**
+    @notice Change the contract's governor. Should be called through the old governance system
+    @param newIGovernor New governor address
+   */
+  function changeIGovernor(IGovernor newIGovernor) public onlyAuthorizedChanger {
+    governor = newIGovernor;
+  }
+
+  // Leave a gap betweeen inherited contracts variables in order to be
+  // able to add more variables in them later
+  uint256[50] private upgradeGap;
+}
+
+
+/**
+  @title UpgradeDelegator
+  @notice Dispatches to the proxyAdmin any call made through the governance system
+  @dev Adapter between our governance system and the zeppelinOS proxyAdmin. This is
+  needed to be able to upgrade governance through the same system
+
+ */
+contract UpgradeDelegator is Governed {
+  ProxyAdmin public proxyAdmin;
+
+  /**
+    @notice Initialize the contract with the basic settings
+    @dev This initialize replaces the constructor but it is not called automatically.
+    It is necessary because of the upgradeability of the contracts
+    @param _governor Governor address of this system
+    @param _proxyAdmin ProxyAdmin that we will forward the call to
+   */
+  function initialize(IGovernor _governor, ProxyAdmin _proxyAdmin) public initializer {
+    Governed.initialize(_governor);
+    proxyAdmin = _proxyAdmin;
+  }
+
+  /**
+   * @dev Returns the current implementation of a proxy.
+   * This is needed because only the proxy admin can query it.
+   * @return The address of the current implementation of the proxy.
+   */
+  function getProxyImplementation(AdminUpgradeabilityProxy proxy) public view returns (address) {
+    return proxyAdmin.getProxyImplementation(proxy);
+  }
+
+  /**
+   * @dev Returns the admin of a proxy. Only the admin can query it.
+   * @return The address of the current admin of the proxy.
+   */
+  function getProxyAdmin(AdminUpgradeabilityProxy proxy) public view returns (address) {
+    return proxyAdmin.getProxyAdmin(proxy);
+  }
+
+  /**
+   * @dev Changes the admin of a proxy.
+   * @param proxy Proxy to change admin.
+   * @param newAdmin Address to transfer proxy administration to.
+   */
+  function changeProxyAdmin(AdminUpgradeabilityProxy proxy, address newAdmin) public onlyAuthorizedChanger {
+    proxyAdmin.changeProxyAdmin(proxy, newAdmin);
+  }
+
+  /**
+   * @dev Upgrades a proxy to the newest implementation of a contract.
+   * @param proxy Proxy to be upgraded.
+   * @param implementation the address of the Implementation.
+   */
+  function upgrade(AdminUpgradeabilityProxy proxy, address implementation) public onlyAuthorizedChanger {
+    proxyAdmin.upgrade(proxy, implementation);
+  }
+
+  /**
+   * @dev Upgrades a proxy to the newest implementation of a contract and forwards a function call to it.
+   * This is useful to initialize the proxied contract.
+   * @param proxy Proxy to be upgraded.
+   * @param implementation Address of the Implementation.
+   * @param data Data to send as msg.data in the low level call.
+   * It should include the signature and the parameters of the function to be called, as described in
+   * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
+   */
+  function upgradeAndCall(AdminUpgradeabilityProxy proxy, address implementation, bytes memory data) public payable onlyAuthorizedChanger {
+    proxyAdmin.upgradeAndCall.value(msg.value)(proxy, implementation, data);
+  }
+}
+
+
+
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow
  * checks.
@@ -283,67 +975,6 @@ contract Pausable is PauserRole {
 
 
 
-/**
- * @title Initializable
- *
- * @dev Helper contract to support initializer functions. To use it, replace
- * the constructor with a function that has the `initializer` modifier.
- * WARNING: Unlike constructors, initializer functions must be manually
- * invoked. This applies both to deploying an Initializable contract, as well
- * as extending an Initializable contract via inheritance.
- * WARNING: When used with inheritance, manual care must be taken to not invoke
- * a parent initializer twice, or ensure that all initializers are idempotent,
- * because this is not dealt with automatically as with constructors.
- */
-contract Initializable {
-
-  /**
-   * @dev Indicates that the contract has been initialized.
-   */
-  bool private initialized;
-
-  /**
-   * @dev Indicates that the contract is in the process of being initialized.
-   */
-  bool private initializing;
-
-  /**
-   * @dev Modifier to use in the initializer function of a contract.
-   */
-  modifier initializer() {
-    require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
-
-    bool isTopLevelCall = !initializing;
-    if (isTopLevelCall) {
-      initializing = true;
-      initialized = true;
-    }
-
-    _;
-
-    if (isTopLevelCall) {
-      initializing = false;
-    }
-  }
-
-  /// @dev Returns true if and only if the function is running in the constructor
-  function isConstructor() private view returns (bool) {
-    // extcodesize checks the size of the code stored in an address, and
-    // address returns the current address. Since the code is still not
-    // deployed when running a constructor, any checks on its code size will
-    // yield zero, making it an effective way to detect if a contract is
-    // under construction or not.
-    uint256 cs;
-    assembly { cs := extcodesize(address) }
-    return cs == 0;
-  }
-
-  // Reserved storage space to allow for layout changes in the future.
-  uint256[50] private ______gap;
-}
-
-
-
 
 
 /**
@@ -520,100 +1151,6 @@ library Math {
         // (a + b) / 2 can overflow, so we distribute
         return (a / 2) + (b / 2) + ((a % 2 + b % 2) / 2);
     }
-}
-
-
-
-
-/**
-  @title ChangeContract
-  @notice This interface is the one used by the governance system.
-  @dev If you plan to do some changes to a system governed by this project you should write a contract
-  that does those changes, like a recipe. This contract MUST not have ANY kind of public or external function
-  that modifies the state of this ChangeContract, otherwise you could run into front-running issues when the governance
-  system is fully in place.
- */
-interface ChangeContract {
-
-  /**
-    @notice Override this function with a recipe of the changes to be done when this ChangeContract
-    is executed
-   */
-  function execute() external;
-}
-
-
-/**
-  @title Governor
-  @notice Governor interface. This functions should be overwritten to
-  enable the comunnication with the rest of the system
-  */
-interface IGovernor{
-
-  /**
-    @notice Function to be called to make the changes in changeContract
-    @dev This function should be protected somehow to only execute changes that
-    benefit the system. This decision process is independent of this architechture
-    therefore is independent of this interface too
-    @param changeContract Address of the contract that will execute the changes
-   */
-  function executeChange(ChangeContract changeContract) external;
-
-  /**
-    @notice Function to be called to make the changes in changeContract
-    @param _changer Address of the contract that will execute the changes
-   */
-  function isAuthorizedChanger(address _changer) external view returns (bool);
-}
-
-
-/**
-  @title Governed
-  @notice Base contract to be inherited by governed contracts
-  @dev This contract is not usable on its own since it does not have any _productive useful_ behaviour
-  The only purpose of this contract is to define some useful modifiers and functions to be used on the
-  governance aspect of the child contract
-  */
-contract Governed is Initializable {
-
-  /**
-    @notice The address of the contract which governs this one
-   */
-  IGovernor public governor;
-
-  string constant private NOT_AUTHORIZED_CHANGER = "not_authorized_changer";
-
-  /**
-    @notice Modifier that protects the function
-    @dev You should use this modifier in any function that should be called through
-    the governance system
-   */
-  modifier onlyAuthorizedChanger() {
-    require(governor.isAuthorizedChanger(msg.sender), NOT_AUTHORIZED_CHANGER);
-    _;
-  }
-
-  /**
-    @notice Initialize the contract with the basic settings
-    @dev This initialize replaces the constructor but it is not called automatically.
-    It is necessary because of the upgradeability of the contracts
-    @param _governor Governor address
-   */
-  function initialize(IGovernor _governor) public initializer {
-    governor = _governor;
-  }
-
-  /**
-    @notice Change the contract's governor. Should be called through the old governance system
-    @param newIGovernor New governor address
-   */
-  function changeIGovernor(IGovernor newIGovernor) public onlyAuthorizedChanger {
-    governor = newIGovernor;
-  }
-
-  // Leave a gap betweeen inherited contracts variables in order to be
-  // able to add more variables in them later
-  uint256[50] private upgradeGap;
 }
 
 
@@ -2887,3 +3424,103 @@ contract MoC is MoCEvents, MoCLibConnection, MoCBase, Stoppable, IMoC {
   uint256[49] private upgradeGap;
 }
 
+
+/**
+  @title MaxGasPriceChanger
+  @notice This contract is an upgradeChanger to add a gas price limit on
+  mint and redeem operation for MoC and RoC protocols
+ */
+contract MaxGasPriceChanger is ChangeContract {
+
+  UpgradeDelegator public upgradeDelegator;
+  AdminUpgradeabilityProxy public MOC_proxy;
+  address public MOC_newImplementation;
+
+  AdminUpgradeabilityProxy public ROC_proxy;
+  address public ROC_newImplementation;
+
+  AdminUpgradeabilityProxy public stopper_proxy;
+  address public stopper_newImplementation;
+
+  uint256 public maxGasPrice;
+
+  /**
+    @notice Constructor
+    @param _upgradeDelegator Address of the upgradeDelegator in charge of that proxy
+    @param _MOC_proxy Address of the MOC proxy to be upgraded
+    @param _MOC_newImplementation Address of the contract the MOC proxy will delegate to
+    @param _ROC_proxy Address of the ROC proxy to be upgraded
+    @param _ROC_newImplementation Address of the contract the ROC proxy will delegate to
+    @param _stopper_newImplementation Address of the contract the Stopper proxy will delegate to
+    @param _maxGasPrice gas price limit to mint and redeem operations
+  */
+  constructor(
+    UpgradeDelegator _upgradeDelegator,
+    AdminUpgradeabilityProxy _MOC_proxy,
+    address _MOC_newImplementation,
+    AdminUpgradeabilityProxy _ROC_proxy,
+    address _ROC_newImplementation,
+    address _stopper_newImplementation,
+    uint256 _maxGasPrice
+    ) public {
+    upgradeDelegator = _upgradeDelegator;
+    MOC_proxy = _MOC_proxy;
+    MOC_newImplementation = _MOC_newImplementation;
+    ROC_proxy = _ROC_proxy;
+    ROC_newImplementation = _ROC_newImplementation;
+    maxGasPrice = _maxGasPrice;
+    stopper_proxy = castToAdminUpgradeabilityProxy(address(MoC(address(_MOC_proxy)).stopper()));
+    stopper_newImplementation = _stopper_newImplementation;
+  }
+
+  /**
+   * @notice cast non payable address to AdminUpgradebilityProxy
+   * @param _address address to cast
+   */
+  function castToAdminUpgradeabilityProxy(address _address) internal returns (AdminUpgradeabilityProxy proxy) {
+    return AdminUpgradeabilityProxy(address(uint160(_address)));
+  }
+
+  /**
+    @notice Execute the changes.
+    @dev Should be called by the governor, but this contract does not check that explicitly because it is not its responsability in
+    the current architecture
+    IMPORTANT: This function should not be overriden, you should only redefine the _beforeUpgrade and _afterUpgrade to use this template
+   */
+  function execute() external {
+    _beforeUpgrade();
+    _upgrade();
+    _afterUpgrade();
+  }
+
+  /**
+    @notice Upgrade the proxy to the newImplementation
+    @dev IMPORTANT: This function should not be overriden
+   */
+  function _upgrade() internal {
+    // upgrade MoC
+    upgradeDelegator.upgrade(MOC_proxy, MOC_newImplementation);
+    // upgrade RoC
+    upgradeDelegator.upgrade(ROC_proxy, ROC_newImplementation);
+    // upgrade Stopper
+    upgradeDelegator.upgrade(stopper_proxy, stopper_newImplementation);
+  }
+
+  /**
+    @notice Intended to prepare the system for the upgrade
+    @dev This function can be overriden by child changers to upgrade contracts that require some preparation before the upgrade
+   */
+  function _beforeUpgrade() internal {
+  }
+
+  /**
+    @notice Intended to do the final tweaks after the upgrade, for example initialize the contract
+    @dev This function can be overriden by child changers to upgrade contracts that require some changes after the upgrade
+   */
+  function _afterUpgrade() internal {
+    // set max gas price to MoC
+    MoC(address(MOC_proxy)).setMaxGasPrice(maxGasPrice);
+    // set max gas price to RoC
+    MoC(address(ROC_proxy)).setMaxGasPrice(maxGasPrice);
+  }
+}

--- a/scripts/contract_flatten/StopperV2_flat.sol
+++ b/scripts/contract_flatten/StopperV2_flat.sol
@@ -1,0 +1,438 @@
+/*
+Copyright MOC Investments Corp. 2020. All rights reserved.
+
+You acknowledge and agree that MOC Investments Corp. (“MOC”) (or MOC’s licensors) own all legal right, title and interest in and to the work, software, application, source code, documentation and any other documents in this repository (collectively, the “Program”), including any intellectual property rights which subsist in the Program (whether those rights happen to be registered or not, and wherever in the world those rights may exist), whether in source code or any other form.
+
+Subject to the limited license below, you may not (and you may not permit anyone else to) distribute, publish, copy, modify, merge, combine with another program, create derivative works of, reverse engineer, decompile or otherwise attempt to extract the source code of, the Program or any part thereof, except that you may contribute to this repository.
+
+You are granted a non-exclusive, non-transferable, non-sublicensable license to distribute, publish, copy, modify, merge, combine with another program or create derivative works of the Program (such resulting program, collectively, the “Resulting Program”) solely for Non-Commercial Use as long as you:
+ 1. give prominent notice (“Notice”) with each copy of the Resulting Program that the Program is used in the Resulting Program and that the Program is the copyright of MOC Investments Corp.; and
+ 2. subject the Resulting Program and any distribution, publication, copy, modification, merger therewith, combination with another program or derivative works thereof to the same Notice requirement and Non-Commercial Use restriction set forth herein.
+
+“Non-Commercial Use” means each use as described in clauses (1)-(3) below, as reasonably determined by MOC Investments Corp. in its sole discretion:
+ 1. personal use for research, personal study, private entertainment, hobby projects or amateur pursuits, in each case without any anticipated commercial application;
+ 2. use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization or government institution; or
+ 3. the number of monthly active users of the Resulting Program across all versions thereof and platforms globally do not exceed 100 at any time.
+
+You will not use any trade mark, service mark, trade name, logo of MOC Investments Corp. or any other company or organization in a way that is likely or intended to cause confusion about the owner or authorized user of such marks, names or logos.
+
+If you have any questions, comments or interest in pursuing any other use cases, please reach out to us at moc.license@moneyonchain.com.
+
+*/
+
+pragma solidity ^0.5.8;
+
+
+
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable {
+
+  /**
+   * @dev Indicates that the contract has been initialized.
+   */
+  bool private initialized;
+
+  /**
+   * @dev Indicates that the contract is in the process of being initialized.
+   */
+  bool private initializing;
+
+  /**
+   * @dev Modifier to use in the initializer function of a contract.
+   */
+  modifier initializer() {
+    require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+
+    bool isTopLevelCall = !initializing;
+    if (isTopLevelCall) {
+      initializing = true;
+      initialized = true;
+    }
+
+    _;
+
+    if (isTopLevelCall) {
+      initializing = false;
+    }
+  }
+
+  /// @dev Returns true if and only if the function is running in the constructor
+  function isConstructor() private view returns (bool) {
+    // extcodesize checks the size of the code stored in an address, and
+    // address returns the current address. Since the code is still not
+    // deployed when running a constructor, any checks on its code size will
+    // yield zero, making it an effective way to detect if a contract is
+    // under construction or not.
+    uint256 cs;
+    assembly { cs := extcodesize(address) }
+    return cs == 0;
+  }
+
+  // Reserved storage space to allow for layout changes in the future.
+  uint256[50] private ______gap;
+}
+
+
+/**
+ * @title Ownable
+ * @dev The Ownable contract has an owner address, and provides basic authorization control
+ * functions, this simplifies the implementation of "user permissions".
+ */
+contract Ownable is Initializable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev The Ownable constructor sets the original `owner` of the contract to the sender
+     * account.
+     */
+    function initialize(address sender) public initializer {
+        _owner = sender;
+        emit OwnershipTransferred(address(0), _owner);
+    }
+
+    /**
+     * @return the address of the owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(isOwner());
+        _;
+    }
+
+    /**
+     * @return true if `msg.sender` is the owner of the contract.
+     */
+    function isOwner() public view returns (bool) {
+        return msg.sender == _owner;
+    }
+
+    /**
+     * @dev Allows the current owner to relinquish control of the contract.
+     * @notice Renouncing to ownership will leave the contract without an owner.
+     * It will not be possible to call the functions with the `onlyOwner`
+     * modifier anymore.
+     */
+    function renounceOwnership() public onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Allows the current owner to transfer control of the contract to a newOwner.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers control of the contract to a newOwner.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function _transferOwnership(address newOwner) internal {
+        require(newOwner != address(0));
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+
+    uint256[50] private ______gap;
+}
+
+
+
+
+
+/**
+  @title ChangeContract
+  @notice This interface is the one used by the governance system.
+  @dev If you plan to do some changes to a system governed by this project you should write a contract
+  that does those changes, like a recipe. This contract MUST not have ANY kind of public or external function
+  that modifies the state of this ChangeContract, otherwise you could run into front-running issues when the governance
+  system is fully in place.
+ */
+interface ChangeContract {
+
+  /**
+    @notice Override this function with a recipe of the changes to be done when this ChangeContract
+    is executed
+   */
+  function execute() external;
+}
+
+
+/**
+  @title Governor
+  @notice Governor interface. This functions should be overwritten to
+  enable the comunnication with the rest of the system
+  */
+interface IGovernor{
+
+  /**
+    @notice Function to be called to make the changes in changeContract
+    @dev This function should be protected somehow to only execute changes that
+    benefit the system. This decision process is independent of this architechture
+    therefore is independent of this interface too
+    @param changeContract Address of the contract that will execute the changes
+   */
+  function executeChange(ChangeContract changeContract) external;
+
+  /**
+    @notice Function to be called to make the changes in changeContract
+    @param _changer Address of the contract that will execute the changes
+   */
+  function isAuthorizedChanger(address _changer) external view returns (bool);
+}
+
+
+/**
+  @title Governed
+  @notice Base contract to be inherited by governed contracts
+  @dev This contract is not usable on its own since it does not have any _productive useful_ behaviour
+  The only purpose of this contract is to define some useful modifiers and functions to be used on the
+  governance aspect of the child contract
+  */
+contract Governed is Initializable {
+
+  /**
+    @notice The address of the contract which governs this one
+   */
+  IGovernor public governor;
+
+  string constant private NOT_AUTHORIZED_CHANGER = "not_authorized_changer";
+
+  /**
+    @notice Modifier that protects the function
+    @dev You should use this modifier in any function that should be called through
+    the governance system
+   */
+  modifier onlyAuthorizedChanger() {
+    require(governor.isAuthorizedChanger(msg.sender), NOT_AUTHORIZED_CHANGER);
+    _;
+  }
+
+  /**
+    @notice Initialize the contract with the basic settings
+    @dev This initialize replaces the constructor but it is not called automatically.
+    It is necessary because of the upgradeability of the contracts
+    @param _governor Governor address
+   */
+  function initialize(IGovernor _governor) public initializer {
+    governor = _governor;
+  }
+
+  /**
+    @notice Change the contract's governor. Should be called through the old governance system
+    @param newIGovernor New governor address
+   */
+  function changeIGovernor(IGovernor newIGovernor) public onlyAuthorizedChanger {
+    governor = newIGovernor;
+  }
+
+  // Leave a gap betweeen inherited contracts variables in order to be
+  // able to add more variables in them later
+  uint256[50] private upgradeGap;
+}
+
+
+
+/**
+  @title Stoppable
+  @notice Allow a contract to be paused through the stopper subsystem. This contracts
+  is able to disable the stoppability feature through governance.
+  @dev This contract was heavily based on the _Pausable_ contract of openzeppelin-eth but
+  it was modified in order to being able to turn on and off its stopability
+ */
+contract Stoppable is Governed {
+
+  event Paused(address account);
+  event Unpaused(address account);
+
+  bool public stoppable;
+  bool private _paused;
+  address public stopper;
+  string private constant UNSTOPPABLE = "unstoppable";
+  string private constant CONTRACT_IS_ACTIVE = "contract_is_active";
+  string private constant CONTRACT_IS_PAUSED = "contract_is_paused";
+  string private constant NOT_STOPPER = "not_stopper";
+
+
+  /**
+    @notice Modifier to make a function callable only when the contract is enable
+    to be paused
+  */
+  modifier whenStoppable() {
+    require(stoppable, UNSTOPPABLE);
+    _;
+  }
+
+  /**
+    @notice Modifier to make a function callable only when the contract is not paused
+  */
+  modifier whenNotPaused() {
+    require(!_paused, CONTRACT_IS_PAUSED);
+    _;
+  }
+
+  /**
+    @notice Modifier to make a function callable only when the contract is paused
+    */
+  modifier whenPaused() {
+    require(_paused, CONTRACT_IS_ACTIVE);
+    _;
+  }
+
+  /**
+    @notice  Modifier to make a function callable only by the pauser
+   */
+  modifier onlyPauser() {
+    require(stopper == msg.sender, NOT_STOPPER);
+    _;
+  }
+
+  /**
+    @notice Initialize the contract with the basic settings
+    @dev This initialize replaces the constructor but it is not called automatically.
+    It is necessary because of the upgradeability of the contracts. Either this function or the next can be used
+    @param _stopper The address that is authorized to stop this contract
+    @param _governor The address that will define when a change contract is authorized to do this unstoppable/stoppable again
+   */
+  function initialize(address _stopper, IGovernor _governor) public initializer {
+    initialize(_stopper, _governor, true);
+  }
+
+  /**
+    @notice Initialize the contract with the basic settings
+    @dev This initialize replaces the constructor but it is not called automatically.
+    It is necessary because of the upgradeability of the contracts. Either this function or the previous can be used
+    @param _stopper The address that is authorized to stop this contract
+    @param _governor The address that will define when a change contract is authorized to do this unstoppable/stoppable again
+    @param _stoppable Define if the contract starts being unstoppable or not
+   */
+  function initialize(address _stopper, IGovernor _governor, bool _stoppable) public initializer {
+    stoppable = _stoppable;
+    stopper = _stopper;
+    Governed.initialize(_governor);
+  }
+
+  /**
+    @notice Returns true if paused
+   */
+  function paused() public view returns (bool) {
+    return _paused;
+  }
+  /**
+    @notice Called by the owner to pause, triggers stopped state
+    @dev Should only be called by the pauser and when it is stoppable
+   */
+  function pause() public whenStoppable onlyPauser whenNotPaused {
+    _paused = true;
+    emit Paused(msg.sender);
+  }
+
+  /**
+    @notice Called by the owner to unpause, returns to normal state
+   */
+  function unpause() public onlyPauser whenPaused {
+    _paused = false;
+    emit Unpaused(msg.sender);
+  }
+
+
+  /**
+    @notice Switches OFF the stoppability of the contract; if the contract was paused
+    it will no longer be so
+    @dev Should be called through governance
+   */
+  function makeUnstoppable() public onlyAuthorizedChanger {
+    stoppable = false;
+  }
+
+
+  /**
+    @notice Switches ON the stoppability of the contract; if the contract was paused
+    before making it unstoppable it will be paused again after calling this function
+    @dev Should be called through governance
+   */
+  function makeStoppable() public onlyAuthorizedChanger {
+    stoppable = true;
+  }
+
+  /**
+    @notice Changes the address which is enable to stop this contract
+    @param newStopper Address of the newStopper
+    @dev Should be called through governance
+   */
+  function setStopper(address newStopper) public onlyAuthorizedChanger {
+    stopper = newStopper;
+  }
+
+  // Leave a gap betweeen inherited contracts variables in order to be
+  // able to add more variables in them later
+  uint256[50] private upgradeGap;
+}
+
+
+/**
+  @title Stopper
+  @notice The contract in charge of handling the stoppability of the contract
+  that define this contract as its stopper
+ */
+contract StopperV2 is Ownable {
+
+  /**
+    @notice Pause activeContract if it is stoppable
+    @param activeContract Contract to be paused
+   */
+  function pause(Stoppable activeContract) external onlyOwner {
+    activeContract.pause();
+  }
+
+  /**
+    @notice Unpause pausedContract if it is stoppable
+    @param pausedContract Contract to be unpaused
+   */
+  function unpause(Stoppable pausedContract) external onlyOwner {
+    pausedContract.unpause();
+  }
+
+  /**
+    @notice set new gas price limit to target contract
+    @param gasPriceLimitedContract Contract to be updated with new gas price limit
+    @param maxGasPrice_ new gas price limit
+   */
+  function setMaxGasPrice(GasPriceLimited gasPriceLimitedContract, uint256 maxGasPrice_) external onlyOwner {
+    gasPriceLimitedContract.setMaxGasPrice(maxGasPrice_);
+  }
+
+  // Leave a gap betweeen inherited contracts variables in order to be
+  // able to add more variables in them later
+  uint256[50] private upgradeGap;
+}
+
+interface GasPriceLimited {
+    /**
+   * @notice set new gas price limit
+   * @param maxGasPrice_ new gas price limit
+   */
+  function setMaxGasPrice(uint256 maxGasPrice_) external;
+}

--- a/scripts/contract_flattener.sh
+++ b/scripts/contract_flattener.sh
@@ -19,6 +19,8 @@ CONTRACTS=(
     "contracts/changers/BatchChanger.sol"
     "contracts/changers/UpgraderChanger.sol"
     "zos-lib/contracts/upgradeability/AdminUpgradeabilityProxy.sol"
+    "contracts/changers/MaxGasPriceChanger.sol"
+    "contracts/governance/StopperV2.sol"
 )
 
 # Working directory: the root of the project

--- a/scripts/deploy/upgrade_v0.1.16/0_deploy.sh
+++ b/scripts/deploy/upgrade_v0.1.16/0_deploy.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+NETWORK=$1
+
+if [[ -z "$NETWORK" ]]; then
+    NETWORK="development"
+fi
+
+echo "Using network '$NETWORK'"
+
+SCRIPTS="
+1_deploy_MoC.js
+2_deploy_Stopper.js
+3_deploy_Changer.js
+4_verification_Changer.js
+"
+
+for S in $SCRIPTS; do
+    echo "------------------------------------------------------------"
+    echo "Running: $S"
+    npx truffle exec $DIR/$S --network $NETWORK
+    [ $? -eq 0 ]  || exit 1
+    echo "------------------------------------------------------------"
+done

--- a/scripts/deploy/upgrade_v0.1.16/1_deploy_MoC.js
+++ b/scripts/deploy/upgrade_v0.1.16/1_deploy_MoC.js
@@ -1,0 +1,27 @@
+/* eslint-disable no-console */
+const MoC = artifacts.require('./MoC.sol');
+
+const { getConfig, getNetwork, saveConfig } = require('../helper');
+
+module.exports = async callback => {
+  try {
+    const network = getNetwork(process.argv);
+    const configPath = `${__dirname}/deployConfig-${network}.json`;
+    const config = getConfig(network, configPath);
+
+    // Deploy contract implementation
+    console.log('Deploying MoC ...');
+    const moc = await MoC.new();
+
+    // Save implementation address to config file
+    config.mocImplementationAddresses.MoC = moc.address;
+
+    saveConfig(config, configPath);
+
+    console.log('MoC implementation address: ', moc.address);
+  } catch (error) {
+    callback(error);
+  }
+
+  callback();
+};

--- a/scripts/deploy/upgrade_v0.1.16/2_deploy_Stopper.js
+++ b/scripts/deploy/upgrade_v0.1.16/2_deploy_Stopper.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-console */
+const Stopper = artifacts.require('./governance/StopperV2.sol');
+const { getConfig, getNetwork, saveConfig } = require('../helper');
+
+module.exports = async callback => {
+  try {
+    const network = getNetwork(process.argv);
+    const configPath = `${__dirname}/deployConfig-${network}.json`;
+    const config = getConfig(network, configPath);
+
+    // Deploy contract implementation
+    console.log('Deploying Stopper ...');
+    const stopper = await Stopper.new();
+
+    // Save implementation address to config file
+    config.governanceImplementationAddresses.Stopper = stopper.address;
+
+    saveConfig(config, configPath);
+
+    console.log('Stopper implementation address: ', stopper.address);
+  } catch (error) {
+    callback(error);
+  }
+
+  callback();
+};

--- a/scripts/deploy/upgrade_v0.1.16/3_deploy_Changer.js
+++ b/scripts/deploy/upgrade_v0.1.16/3_deploy_Changer.js
@@ -1,0 +1,46 @@
+/* eslint-disable no-console */
+const Governor = artifacts.require('moc-governance/contracts/Governance/Governor.sol');
+const MaxGasPriceChanger = artifacts.require('./changers/MaxGasPriceChanger.sol');
+
+const { getConfig, getNetwork, saveConfig, shouldExecuteChanges } = require('../helper');
+
+module.exports = async callback => {
+  try {
+    const network = getNetwork(process.argv);
+    const configPath = `${__dirname}/deployConfig-${network}.json`;
+    const config = getConfig(network, configPath);
+
+    console.log('MaxGasPriceChanger Deploy');
+    const maxGasPriceChanger = await MaxGasPriceChanger.new(
+      config.governanceImplementationAddresses.UpgradeDelegator,
+      config.mocProxyAddresses.MoC,
+      config.mocImplementationAddresses.MoC,
+      config.rocProxyAddresses.MoC,
+      config.rocImplementationAddresses.MoC,
+      config.governanceImplementationAddresses.Stopper,
+      config.valuesToAssign.maxGasPrice
+    );
+    console.log('MaxGasPriceChanger address: ', maxGasPriceChanger.address);
+
+    // Save changer address to config file
+    config.changerAddresses.MaxGasPriceChanger = maxGasPriceChanger.address;
+    saveConfig(config, configPath);
+
+    // if (shouldExecuteChanges(network)) {
+    //   // Execute changes in contracts
+    //   console.log('Execute change - Changer');
+    //   const governor = await Governor.at(config.mocImplementationAddresses.Governor);
+    //   await governor.executeChange(maxGasPriceChanger.address);
+    // } else {
+    //   console.log('Executing test governor execute change');
+    //   const governor = await Governor.at(config.mocImplementationAddresses.Governor);
+    //   await governor.contract.methods
+    //     .executeChange(config.changerAddresses.Changer)
+    //     .call({ from: config.governorOwnerAddress });
+    // }
+  } catch (error) {
+    callback(error);
+  }
+
+  callback();
+};

--- a/scripts/deploy/upgrade_v0.1.16/4_verification_Changer.js
+++ b/scripts/deploy/upgrade_v0.1.16/4_verification_Changer.js
@@ -1,0 +1,127 @@
+/* eslint-disable no-console */
+const contract = require('truffle-contract');
+
+const MaxGasPriceChanger = artifacts.require('./changers/MaxGasPriceChanger.sol');
+const MoC = artifacts.require('./MoC.sol');
+const { getConfig, getNetwork } = require('../helper');
+
+const ROC_ABI = [
+  {
+    constant: true,
+    inputs: [],
+    name: 'getRiskProRate',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function'
+  }
+];
+
+module.exports = async callback => {
+  try {
+    const network = getNetwork(process.argv);
+    const configPath = `${__dirname}/deployConfig-${network}.json`;
+    const config = getConfig(network, configPath);
+
+    const changerAddress = config.changerAddresses.MaxGasPriceChanger;
+    const changer = await MaxGasPriceChanger.at(changerAddress);
+
+    const RoC = contract({
+      abi: ROC_ABI,
+      address: config.rocProxyAddresses.MoC
+    });
+
+    await RoC.setProvider(MaxGasPriceChanger.currentProvider);
+
+    const changerInfo = {};
+    changerInfo.upgradeDelegator = await changer.upgradeDelegator();
+    changerInfo.mocProxy = await changer.MOC_proxy();
+    changerInfo.mocNewImplementation = await changer.MOC_newImplementation();
+
+    changerInfo.rocProxy = await changer.ROC_proxy();
+    changerInfo.rocNewImplementation = await changer.ROC_newImplementation();
+
+    changerInfo.stopperNewImplementation = await changer.stopper_newImplementation();
+
+    changerInfo.maxGasPrice = (await changer.maxGasPrice()).toString();
+
+    console.log('Changer contract parameters');
+    const moc = await MoC.at(config.mocProxyAddresses.MoC);
+    const roc = await RoC.at(config.rocProxyAddresses.MoC);
+    try {
+      await moc.getBitProRate();
+      console.log('OK. MoC Proxy: ', config.mocProxyAddresses.MoC);
+    } catch (error) {
+      console.log('ERROR MoC Proxy: ', config.mocProxyAddresses.MoC);
+    }
+    try {
+      await roc.getRiskProRate();
+      console.log('OK. RoC Proxy: ', config.rocProxyAddresses.MoC);
+    } catch (error) {
+      console.log('ERROR RoC Proxy: ', config.rocProxyAddresses.MoC);
+    }
+
+    if (
+      changerInfo.upgradeDelegator === config.governanceImplementationAddresses.UpgradeDelegator
+    ) {
+      console.log('OK. UpgradeDelegator: ', changerInfo.upgradeDelegator);
+    } else {
+      console.log('ERROR! UpgradeDelegator is not the same ', changerInfo.upgradeDelegator);
+    }
+
+    if (changerInfo.mocProxy === config.mocProxyAddresses.MoC) {
+      console.log('OK. MoC Proxy: ', changerInfo.mocProxy);
+    } else {
+      console.log('ERROR! MoC Proxy is not the same ', changerInfo.mocProxy);
+    }
+
+    if (changerInfo.mocNewImplementation === config.mocImplementationAddresses.MoC) {
+      console.log('OK. MoC NewImplementation: ', changerInfo.mocNewImplementation);
+    } else {
+      console.log(
+        'ERROR! MoC NewImplementation is not the same ',
+        changerInfo.mocNewImplementation
+      );
+    }
+
+    if (changerInfo.rocProxy === config.rocProxyAddresses.MoC) {
+      console.log('OK. RoC Proxy: ', changerInfo.rocProxy);
+    } else {
+      console.log('ERROR! RoC Proxy is not the same ', changerInfo.rocProxy);
+    }
+
+    if (changerInfo.rocNewImplementation === config.rocImplementationAddresses.MoC) {
+      console.log('OK. RoC NewImplementation: ', changerInfo.rocNewImplementation);
+    } else {
+      console.log(
+        'ERROR! RoC NewImplementation is not the same ',
+        changerInfo.rocNewImplementation
+      );
+    }
+
+    if (changerInfo.stopperNewImplementation === config.governanceImplementationAddresses.Stopper) {
+      console.log('OK. Stopper NewImplementation: ', changerInfo.stopperNewImplementation);
+    } else {
+      console.log(
+        'ERROR! Stopper NewImplementation is not the same ',
+        changerInfo.stopperNewImplementation
+      );
+    }
+
+    if (changerInfo.maxGasPrice === config.valuesToAssign.maxGasPrice.toString()) {
+      console.log('OK. maxGasPrice: ', changerInfo.maxGasPrice);
+    } else {
+      console.log('ERROR! maxGasPrice is not the same ', changerInfo.maxGasPrice);
+    }
+  } catch (error) {
+    callback(error);
+  }
+
+  callback();
+};

--- a/scripts/deploy/upgrade_v0.1.16/deployConfig-example.json
+++ b/scripts/deploy/upgrade_v0.1.16/deployConfig-example.json
@@ -1,0 +1,28 @@
+{
+  "mocProxyAddresses": {
+    "MoC": "0xD34B89ceE8dD865b232D9701C4127fB6b7D04F2C"
+  },
+  "mocImplementationAddresses": {
+    "MoC": "0x0Dc19Fd39c67cC06E083770D9c81C808eaA905da",
+    "UpgradeDelegator": "0xB697E0F1cF39623969E7ED15d0D27405D5fB3309",
+    "Governor": "0x53a28117849B8Aa4f53BCF90813065E9C93c2D95"
+  },
+  "rocProxyAddresses": {
+    "MoC": "0xd621eBAd2e364Bcc0ca2681aB349B65d9a458e8a"
+  },
+  "rocImplementationAddresses": {
+    "MoC": "0x442a3cAc6cD4C9c3828414dAda004133831201aA",
+    "UpgradeDelegator": "0x642d222EBC8E5cC3a74Cd2c79A50aD34c57fe97c"
+  },
+  "governanceImplementationAddresses": {
+    "UpgradeDelegator": "0xB697E0F1cF39623969E7ED15d0D27405D5fB3309",
+    "Stopper": "0x70Bb6B04132eF9126DAb4622eC86CC17EF93842E"
+  },
+  "valuesToAssign": {
+    "gasPriceManagerAddress": "0x642d222EBC8E5cC3a74Cd2c79A50aD34c57fe97c",
+    "maxGasPrice": 70000000
+  },
+  "changerAddresses": {
+    "MaxGasPriceChanger": "0x5De04a4d8c53109E807473a219d3405B90605b8C"
+  }
+}

--- a/scripts/deploy/upgrade_v0.1.16/deployConfig-rskAlphaTestnet-original.json
+++ b/scripts/deploy/upgrade_v0.1.16/deployConfig-rskAlphaTestnet-original.json
@@ -1,0 +1,29 @@
+{
+  "mocProxyAddresses": {
+    "MoC": "0x01AD6f8E884ed4DDC089fA3efC075E9ba45C9039"
+  },
+  "mocImplementationAddresses": {
+    "MoC": "",
+    "UpgradeDelegator": "0x00a47D7d7B9bD22e0A862908EC493bDE893f627B",
+    "Governor": "0x7b716178771057195bB511f0B1F7198EEE62Bc22"
+  },
+  "rocProxyAddresses": {
+    "MoC": "0x4512f4C1d984bbf8B7f7404EddFb1881cFA79EfD"
+  },
+  "rocImplementationAddresses": {
+    "MoC": "",
+    "UpgradeDelegator": "0xCDAbFbF334A5F6BCe900D2f73470D1e6722365d8",
+    "Governor": "0x7b716178771057195bB511f0B1F7198EEE62Bc22"
+  },
+  "governanceImplementationAddresses": {
+    "UpgradeDelegator": "0xCDAbFbF334A5F6BCe900D2f73470D1e6722365d8",
+    "Stopper": ""
+  },
+  "valuesToAssign": {
+    "maxGasPrice": 65820000
+  },
+  "changerAddresses": {
+    "MaxGasPriceChanger": ""
+  },
+  "governorOwnerAddress": "0x7D124cC0f59aDA5793AD8edA9eD1836cB7e797a3"
+}

--- a/scripts/deploy/upgrade_v0.1.16/deployConfig-rskAlphaTestnet.json
+++ b/scripts/deploy/upgrade_v0.1.16/deployConfig-rskAlphaTestnet.json
@@ -1,0 +1,29 @@
+{
+  "mocProxyAddresses": {
+    "MoC": "0x01AD6f8E884ed4DDC089fA3efC075E9ba45C9039"
+  },
+  "mocImplementationAddresses": {
+    "MoC": "0x9F9aB68C63414Be221dac000B01575a9c86516AA",
+    "UpgradeDelegator": "0x00a47D7d7B9bD22e0A862908EC493bDE893f627B",
+    "Governor": "0x7b716178771057195bB511f0B1F7198EEE62Bc22"
+  },
+  "rocProxyAddresses": {
+    "MoC": "0x4512f4C1d984bbf8B7f7404EddFb1881cFA79EfD"
+  },
+  "rocImplementationAddresses": {
+    "MoC": "0xaBD6D0bC934269634Fc8840431e68304150bb832",
+    "UpgradeDelegator": "0xCDAbFbF334A5F6BCe900D2f73470D1e6722365d8",
+    "Governor": "0x7b716178771057195bB511f0B1F7198EEE62Bc22"
+  },
+  "governanceImplementationAddresses": {
+    "UpgradeDelegator": "0xCDAbFbF334A5F6BCe900D2f73470D1e6722365d8",
+    "Stopper": "0xbf25747bcEd6a38DdD02F10357995bd58a6E903c"
+  },
+  "valuesToAssign": {
+    "maxGasPrice": 65820000
+  },
+  "changerAddresses": {
+    "MaxGasPriceChanger": ""
+  },
+  "governorOwnerAddress": "0x7D124cC0f59aDA5793AD8edA9eD1836cB7e797a3"
+}

--- a/scripts/deploy/upgrade_v0.1.16/deployConfig-rskMocMainnet2-original.json
+++ b/scripts/deploy/upgrade_v0.1.16/deployConfig-rskMocMainnet2-original.json
@@ -1,0 +1,29 @@
+{
+  "mocProxyAddresses": {
+    "MoC": "0xf773B590aF754D597770937Fa8ea7AbDf2668370"
+  },
+  "mocImplementationAddresses": {
+    "MoC": "",
+    "UpgradeDelegator": "0x5cE577f6Ec969CE9a282838D350206C52A6F338C",
+    "Governor": "0x3b8853DF65AfBd94853E6D77ee0Ab5590F41bB08"
+  },
+  "rocProxyAddresses": {
+    "MoC": "0xCfF3fcaeC2352C672C38d77cb1a064B7D50ce7e1"
+  },
+  "rocImplementationAddresses": {
+    "MoC": "",
+    "UpgradeDelegator": "0x5cE577f6Ec969CE9a282838D350206C52A6F338C",
+    "Governor": "0x3b8853DF65AfBd94853E6D77ee0Ab5590F41bB08"
+  },
+  "governanceImplementationAddresses": {
+    "UpgradeDelegator": "0x5cE577f6Ec969CE9a282838D350206C52A6F338C",
+    "Stopper": ""
+  },
+  "valuesToAssign": {
+    "maxGasPrice": 65820000
+  },
+  "changerAddresses": {
+    "MaxGasPriceChanger": ""
+  },
+  "governorOwnerAddress": "0x65a5681bE95d212F0c90eAd40170D8277de81169"
+}

--- a/scripts/deploy/upgrade_v0.1.16/deployConfig-rskMocMainnet2.json
+++ b/scripts/deploy/upgrade_v0.1.16/deployConfig-rskMocMainnet2.json
@@ -1,0 +1,29 @@
+{
+  "mocProxyAddresses": {
+    "MoC": "0xf773B590aF754D597770937Fa8ea7AbDf2668370"
+  },
+  "mocImplementationAddresses": {
+    "MoC": "0x54D9b8eB88F2E193C427b5134368f2DFaEd8B979",
+    "UpgradeDelegator": "0x5cE577f6Ec969CE9a282838D350206C52A6F338C",
+    "Governor": "0x3b8853DF65AfBd94853E6D77ee0Ab5590F41bB08"
+  },
+  "rocProxyAddresses": {
+    "MoC": "0xCfF3fcaeC2352C672C38d77cb1a064B7D50ce7e1"
+  },
+  "rocImplementationAddresses": {
+    "MoC": "0xbe903D6E77aE2Da5C9fb7F6518211495f67D30bd",
+    "UpgradeDelegator": "0x5cE577f6Ec969CE9a282838D350206C52A6F338C",
+    "Governor": "0x3b8853DF65AfBd94853E6D77ee0Ab5590F41bB08"
+  },
+  "governanceImplementationAddresses": {
+    "UpgradeDelegator": "0x5cE577f6Ec969CE9a282838D350206C52A6F338C",
+    "Stopper": "0x10D337Eb8E72fe0674C80634BFFDCCaFC3264c29"
+  },
+  "valuesToAssign": {
+    "maxGasPrice": 65820000
+  },
+  "changerAddresses": {
+    "MaxGasPriceChanger": "0x9088fd1dA8aa13dfa6Fc665F449790bE5a799341"
+  },
+  "governorOwnerAddress": "0x65a5681bE95d212F0c90eAd40170D8277de81169"
+}

--- a/scripts/deploy/upgrade_v0.1.16/deployConfig-rskMocTestnet-original.json
+++ b/scripts/deploy/upgrade_v0.1.16/deployConfig-rskMocTestnet-original.json
@@ -1,0 +1,29 @@
+{
+  "mocProxyAddresses": {
+    "MoC": "0x2820f6d4D199B8D8838A4B26F9917754B86a0c1F"
+  },
+  "mocImplementationAddresses": {
+    "MoC": "",
+    "UpgradeDelegator": "0xCDAbFbF334A5F6BCe900D2f73470D1e6722365d8",
+    "Governor": "0x7b716178771057195bB511f0B1F7198EEE62Bc22"
+  },
+  "rocProxyAddresses": {
+    "MoC": "0x7e2F245F7dc8e78576ECB13AEFc0a101E9BE1AD3"
+  },
+  "rocImplementationAddresses": {
+    "MoC": "",
+    "UpgradeDelegator": "0xCDAbFbF334A5F6BCe900D2f73470D1e6722365d8",
+    "Governor": "0x7b716178771057195bB511f0B1F7198EEE62Bc22"
+  },
+  "governanceImplementationAddresses": {
+    "UpgradeDelegator": "0xCDAbFbF334A5F6BCe900D2f73470D1e6722365d8",
+    "Stopper": ""
+  },
+  "valuesToAssign": {
+    "maxGasPrice": 65820000
+  },
+  "changerAddresses": {
+    "MaxGasPriceChanger": ""
+  },
+  "governorOwnerAddress": "0x7D124cC0f59aDA5793AD8edA9eD1836cB7e797a3"
+}

--- a/scripts/deploy/upgrade_v0.1.16/deployConfig-rskMocTestnet.json
+++ b/scripts/deploy/upgrade_v0.1.16/deployConfig-rskMocTestnet.json
@@ -1,0 +1,29 @@
+{
+  "mocProxyAddresses": {
+    "MoC": "0x2820f6d4D199B8D8838A4B26F9917754B86a0c1F"
+  },
+  "mocImplementationAddresses": {
+    "MoC": "0xcb6e7D32CB73B197E9Ec5858b238126a79f5DcfC",
+    "UpgradeDelegator": "0xCDAbFbF334A5F6BCe900D2f73470D1e6722365d8",
+    "Governor": "0x7b716178771057195bB511f0B1F7198EEE62Bc22"
+  },
+  "rocProxyAddresses": {
+    "MoC": "0x7e2F245F7dc8e78576ECB13AEFc0a101E9BE1AD3"
+  },
+  "rocImplementationAddresses": {
+    "MoC": "0x9481B8895D98ec6f639984Ec06326Daf0bB09faA",
+    "UpgradeDelegator": "0xCDAbFbF334A5F6BCe900D2f73470D1e6722365d8",
+    "Governor": "0x7b716178771057195bB511f0B1F7198EEE62Bc22"
+  },
+  "governanceImplementationAddresses": {
+    "UpgradeDelegator": "0xCDAbFbF334A5F6BCe900D2f73470D1e6722365d8",
+    "Stopper": "0xbf25747bcEd6a38DdD02F10357995bd58a6E903c"
+  },
+  "valuesToAssign": {
+    "maxGasPrice": 65820000
+  },
+  "changerAddresses": {
+    "MaxGasPriceChanger": "0x69C39BA84078B741fcF76c74D1Fd7cBdfa70085C"
+  },
+  "governorOwnerAddress": "0x7D124cC0f59aDA5793AD8edA9eD1836cB7e797a3"
+}

--- a/test/changers/maxGasPriceChanger/MaxGasPriceChanger-test.js
+++ b/test/changers/maxGasPriceChanger/MaxGasPriceChanger-test.js
@@ -1,0 +1,79 @@
+const { expectRevert } = require('openzeppelin-test-helpers');
+const testHelperBuilder = require('../../mocHelper.js');
+
+let mocHelper;
+let toContractBN;
+const Upgrader = artifacts.require('./contracts/changers/UpgraderChanger.sol');
+const Changer = artifacts.require('./contracts/changers/MaxGasPriceChanger.sol');
+const MoCv0115 = artifacts.require('./contracts_updated/MoC_v0115.sol');
+const MoC = artifacts.require('./contracts/MoC.sol');
+const StopperV2 = artifacts.require('./contracts/governance/StopperV2.sol');
+let changer;
+let mocv0115;
+let moc;
+
+contract('MoC: MaxGasPriceChanger', function([owner]) {
+  before(async function() {
+    mocHelper = await testHelperBuilder({ owner });
+    ({ toContractBN } = mocHelper);
+    this.moc = mocHelper.moc;
+  });
+  describe('GIVEN a MoC_v0115 deployed', function() {
+    before(async function() {
+      // to re-use deployments and simplify the test we first
+      // upgrade MoC to the old implementation MoC_v0115
+      mocv0115 = await MoCv0115.new({ from: owner });
+      const upgrader = await Upgrader.new(
+        mocHelper.moc.address,
+        mocHelper.upgradeDelegator.address,
+        mocv0115.address,
+        { from: owner }
+      );
+      await mocHelper.governor.executeChange(upgrader.address, { from: owner });
+    });
+    describe('WHEN an user mints 1000 BPro using a high gas price', function() {
+      before(async function() {
+        await mocHelper.moc.mintBPro(toContractBN(1000 * mocHelper.MOC_PRECISION), {
+          from: owner,
+          value: toContractBN(1000 * mocHelper.MOC_PRECISION),
+          gasPrice: '21000000001'
+        });
+      });
+      it('THEN he has 1000 BPro', async function() {
+        const balance = await mocHelper.getBProBalance(owner);
+        mocHelper.assertBigRBTC(balance, 1000, 'userAccount BBProPro balance was not 10000');
+      });
+      describe('AND new MoC implementation is deployed and changer executed', function() {
+        before(async function() {
+          moc = await MoC.new({ from: owner });
+          const stopperV2 = await StopperV2.new({ from: owner });
+          changer = await Changer.new(
+            mocHelper.upgradeDelegator.address,
+            mocHelper.moc.address,
+            moc.address,
+            mocHelper.moc.address, // should be ROC address but it's not relevant for this test
+            moc.address,
+            stopperV2.address,
+            '21000000000', // max gas price
+            { from: owner }
+          );
+          await mocHelper.governor.executeChange(changer.address, { from: owner });
+        });
+        it('THEN user still has 1000 BPro', async function() {
+          const balance = await mocHelper.getBProBalance(owner);
+          mocHelper.assertBigRBTC(balance, 1000, 'userAccount BPro balance was not 10000');
+        });
+        it('THEN max gas price is applied', async function() {
+          const maxGasPrice = await mocHelper.moc.maxGasPrice();
+          mocHelper.assertBig(maxGasPrice, '21000000000', 'maxGasPrice was not 21000000000');
+        });
+        describe('WHEN user tries to mint BPro using a high gas price than the limit', function() {
+          it('THEN transaction reverts because uses a higher gas price', async function() {
+            const tx = mocHelper.moc.mintBPro(1000, { value: 1000, gasPrice: '21000000001' });
+            await expectRevert(tx, 'gas price is above the max allowed');
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/moc/MoCDocMinting-test.js
+++ b/test/moc/MoCDocMinting-test.js
@@ -45,6 +45,12 @@ contract('MoC', function([owner, userAccount, vendorAccount]) {
       beforeEach(async function() {
         await mocHelper.mintBPro(userAccount, 1, vendorAccount);
       });
+      describe('WHEN he tries to mint DOC with a higher gas price than the limit', function() {
+        it('THEN transaction reverts because uses a higher gas price', async function() {
+          const tx = mocHelper.moc.mintDoc(1000, { value: 1000, gasPrice: '21000000001' });
+          await expectRevert(tx, 'gas price is above the max allowed');
+        });
+      });
       describe('WHEN a user tries to mint 10000 Docs', function() {
         let prevBtcBalance;
         let txCost;

--- a/test/testHelpers/contractsBuilder.js
+++ b/test/testHelpers/contractsBuilder.js
@@ -330,7 +330,13 @@ const createContracts = params => async ({ owner, useMock }) => {
     mocInrate.address,
     mocVendors.address // pass other address as parameter because MoCBurnout is deprecated
   );
-  await moc.initialize(mocConnector.address, governor.address, stopper.address, startStoppable);
+  await moc.initialize(
+    mocConnector.address,
+    governor.address,
+    stopper.address,
+    startStoppable,
+    21000000000 // max gas price
+  );
   await stopper.initialize(owner);
   await mocExchange.initialize(mocConnector.address);
   // Making sure to call the correct initialize function
@@ -413,7 +419,8 @@ const createContracts = params => async ({ owner, useMock }) => {
     mocPriceProvider,
     mocExchange,
     mocVendors,
-    mockMoCVendorsChanger
+    mockMoCVendorsChanger,
+    upgradeDelegator
   };
 };
 


### PR DESCRIPTION
**Technical proposal for Enhancing Transaction Cost Management for Users with Ethereum-based Gas Price Settings**
​
Date: **2023-06-15
Autor: **Juan S. Bokser**
Status: **DRAFT**
​
For the proposal in ***[Enhancing Transaction Cost Management for Users with Ethereum-based Gas Price Setting]()*** it will require a smart contract upgrade, ensuring that transactions with gas prices exceeding a defined threshold are automatically rejected.
​
To implement this enhancement, the propose will introduce a modifier in each operation that validates the `gas price` and rejects the transaction if it exceeds the threshold. By incorporating this modifier, we can effectively prevent transactions with excessive gas prices from being processed.
​
To ensure comprehensive coverage, it is necessary to apply this modifier for the `redeem` and `mint` operations of every token in the protocol.
​
In order to implement this modification, a smart contract upgrade through vote will be necessary. This upgrade will enable the integration of the gas price threshold validation logic within the existing codebase of the *Money On Chain* and *Rif On Chain* protocol.
​
To maintain the integrity and usability of the protocol, it is crucial to allow modification of the gas price threshold. However, this modification should only be able to be made by the `address` with the authority to pause the protocol, This restriction will ensure that any changes made to the threshold are carried out through authorization via governance.
​
Assuming that users will operate with the `gas price` reported by the RSK network node, to set the initial threshold the suggestions is take the historical maximum of the last year plus `1 wei`. That gives a value of `0.0658 Gwei`. 